### PR TITLE
feat: enable process sandboxing

### DIFF
--- a/src/process/index.js
+++ b/src/process/index.js
@@ -6,6 +6,7 @@ const {MessageChannel, ProcessManager} = require('electron-re')
 // Import Files
 let MainWindow = require('./window')
 
+app.enableSandbox()
 // Launch
 app.whenReady().then(() => {
     autoUpdater.checkForUpdatesAndNotify()

--- a/src/process/preload.js
+++ b/src/process/preload.js
@@ -1,5 +1,4 @@
 const { contextBridge, ipcRenderer} = require("electron")
-const path = require('path')
 
 contextBridge.exposeInMainWorld( "api", { send: (channel, data) => {let validChannels = [
   "updateApp",

--- a/src/process/window.js
+++ b/src/process/window.js
@@ -37,7 +37,6 @@ module.exports = {
       icon: global.AppIcon,
       webPreferences: {
         preload: path.join(app.getAppPath(), 'src/process/preload.js'),
-        sandbox: false, // App doens't load properly if enabled
         webviewTag: true
       }
     })


### PR DESCRIPTION
Restored sandboxing for the main window renderer and enabled global sandboxing to ensure that every renderer process is sandboxed. You can read more about the sandboxing feature in the [Electron documentation](https://www.electronjs.org/docs/latest/tutorial/sandbox).