### PR TITLE
Fix metainfo formatting

### DIFF
--- a/build/flatpak/com.authormore.penpotdesktop.metainfo.xml
+++ b/build/flatpak/com.authormore.penpotdesktop.metainfo.xml
@@ -58,11 +58,9 @@
             <description>
                 <p>Features</p>
                 <ul>
-                    <li>Added a tab management menu.
-                        <ul>
-                            <li>Added a context menu for a tab item. It gives you an option to reload or duplicate a tab, or batch close [other, right, left] tabs in relation to the targeted one.</li>
-                        </ul>
-                    </li>
+                    <li>Added a tab management menu.</li>
+                    <li>Added a context menu for a tab item. It gives you an option to reload or duplicate a tab, or batch 
+                    close [other, right, left] tabs in relation to the targeted one.</li>
                 </ul>
                 <p>Improvements</p>
                 <ul>
@@ -70,14 +68,11 @@
                 </ul>
                 <p>Internal</p>
                 <ul>
-                    <li>Cleaned up dependencies.
-                        <ul>
-                            <li>Refactored styling to CSS, removed Sass.</li> 
-                            <li>Removed unused dependencies.</li>
-                        </ul>
-                    </li>
+                    <li>Cleaned up dependencies.</li>
+                    <li>Refactored styling to CSS, removed Sass.</li>
+                    <li>Removed unused dependencies.</li>
                 </ul>
-            </description> 
+            </description>
         </release>
         <release version="v0.6.0" date="2024-12-04">
             <description>


### PR DESCRIPTION
Sorry, I've overlooked the nested ul tags in the [description rules](https://docs.flathub.org/docs/for-app-authors/metainfo-guidelines/#description) in #40
> Only the following child tags are supported: p (paragraph), ol, ul (ordered and unordered list) with li (list items) child tags, em for italicized emphasis and code for inline code in monospace.
> 
> The description must have at least one non empty p, ol or ul tag. It must not contain any direct URLs.

We should probably add the [flatpak-builder-lint](https://github.com/flathub-infra/flatpak-builder-lint) to the release workflow checks next time :sweat_smile:

(Don't need a point release, can use a commit again, sowwy ;3)