### PR TITLE
feat: add themes support

### DIFF
--- a/src/base/components/settings.html
+++ b/src/base/components/settings.html
@@ -8,7 +8,7 @@
             <input id="instance-save" type="button" value="Save" />
         </div>
     </div>
-    <!-- <div class="settings-section">
+    <div class="settings-section">
         <div class="settings-section-header">
             <h2>Theme</h2>
         </div>
@@ -16,7 +16,7 @@
             <div onclick="localStorage.setItem('theme', 'light'); document.body.classList.add('theme-is-light'); document.body.classList.remove('theme-is-dark')" id="theme-select-light" class="theme-selection"><p>Light</p></div>
             <div onclick="localStorage.setItem('theme', 'dark'); document.body.classList.add('theme-is-dark'); document.body.classList.remove('theme-is-light')" id="theme-select-dark" class="theme-selection"><p>Dark</p></div>
         </div>
-    </div> -->
+    </div>
     <div class="settings-section">
         <div class="settings-section-header">
             <h2>Help</h2>

--- a/src/base/components/settings.html
+++ b/src/base/components/settings.html
@@ -13,8 +13,11 @@
             <h2>Theme</h2>
         </div>
         <div id="theme" class="settings-section-content">
-            <button id="theme-select-light" class="theme-selection">Light</button>
-            <button id="theme-select-dark" class="theme-selection">Dark</button>
+            <select name="theme" id="theme-select">
+                <option value="light">Light</option>
+                <option value="dark">Dark</option>
+                <option value="system">System</option>
+            </select>
         </div>
     </div>
     <div class="settings-section">

--- a/src/base/components/settings.html
+++ b/src/base/components/settings.html
@@ -13,8 +13,8 @@
             <h2>Theme</h2>
         </div>
         <div id="theme" class="settings-section-content">
-            <div onclick="localStorage.setItem('theme', 'light'); document.body.classList.add('theme-is-light'); document.body.classList.remove('theme-is-dark')" id="theme-select-light" class="theme-selection"><p>Light</p></div>
-            <div onclick="localStorage.setItem('theme', 'dark'); document.body.classList.add('theme-is-dark'); document.body.classList.remove('theme-is-light')" id="theme-select-dark" class="theme-selection"><p>Dark</p></div>
+            <button id="theme-select-light" class="theme-selection">Light</button>
+            <button id="theme-select-dark" class="theme-selection">Dark</button>
         </div>
     </div>
     <div class="settings-section">

--- a/src/base/components/settings.html
+++ b/src/base/components/settings.html
@@ -17,6 +17,7 @@
                 <option value="light">Light</option>
                 <option value="dark">Dark</option>
                 <option value="system">System</option>
+                <option value="tab">Penpot</option>
             </select>
         </div>
     </div>

--- a/src/base/components/tabs.html
+++ b/src/base/components/tabs.html
@@ -31,6 +31,7 @@
             border: none !important;
             height: var(--tab-height);
             width: calc(100% - var(--navBarWF));
+            filter: var(--theme-filter, none);
 
             margin-left: 2.25rem;
         }

--- a/src/base/index.html
+++ b/src/base/index.html
@@ -11,7 +11,7 @@
         <script src="./scripts/theme.js"></script>
         <script src="./scripts/toggles.js"></script>
     </head> 
-    <body onload="ThemeCheck();">
+    <body>
         <drag></drag>
         <sl-include id="include-controls" src="./components/controls.html"></sl-include>
         <sl-include src="./components/titlebar.html"></sl-include>

--- a/src/base/scripts/electron-tabs.js
+++ b/src/base/scripts/electron-tabs.js
@@ -86,9 +86,7 @@ function tabReadyHandler(tab) {
   const webview = /** @type {WebviewTag} */ (tab.webview);
 
   tab.once("webview-dom-ready", () => {
-    tab.on("active", () => {
-      webview.send(THEME_TAB_EVENTS.REQUEST_UPDATE);
-    });
+    tab.on("active", () => requestTabTheme(tab));
   });
   tab.element.addEventListener("contextmenu", (event) => {
     event.preventDefault();
@@ -106,6 +104,26 @@ function tabReadyHandler(tab) {
     const newTitle = webview.getTitle();
     tab.setTitle(newTitle);
   });
+}
+
+/**
+ * Calls a tab and requests a theme update send-out. 
+ * If no tab is provided, calls the active tab.
+ *  
+ * @param {Tab =} tab
+ */
+async function requestTabTheme(tab) {
+  tab = tab || (await getActiveTab());
+
+  if (tab) {
+    const webview = /** @type {WebviewTag} */ (tab.webview);
+    webview?.send(THEME_TAB_EVENTS.REQUEST_UPDATE);
+  }
+}
+
+async function getActiveTab() {
+  const tabGroup = await getTabGroup();
+  return tabGroup?.getActiveTab();
 }
 
 async function getTabGroup() {

--- a/src/base/scripts/electron-tabs.js
+++ b/src/base/scripts/electron-tabs.js
@@ -85,9 +85,22 @@ async function prepareTabReloadButton() {
 function tabReadyHandler(tab) {
   const webview = /** @type {WebviewTag} */ (tab.webview);
 
+  tab.once("webview-dom-ready", () => {
+    tab.on("active", () => {
+      webview.send(THEME_TAB_EVENTS.REQUEST_UPDATE);
+    });
+  });
   tab.element.addEventListener("contextmenu", (event) => {
     event.preventDefault();
     window.api.send("openTabMenu", tab.id);
+  });
+  webview.addEventListener("ipc-message", (event) => {
+    const isThemeUpdate = event.channel === THEME_TAB_EVENTS.UPDATE;
+    if (isThemeUpdate) {
+      const [theme] = event.args;
+
+      handleInTabThemeUpdate(theme);
+    }
   });
   webview.addEventListener("page-title-updated", () => {
     const newTitle = webview.getTitle();

--- a/src/base/scripts/theme.js
+++ b/src/base/scripts/theme.js
@@ -13,14 +13,27 @@ window.addEventListener("DOMContentLoaded", () => {
     setTheme(themeId);
   }
 
-  prepareForm();
+  prepareForm(themeId);
 });
 
-async function prepareForm() {
-  const { themeSelectLight, themeSelectDark } = await getThemeSettingsForm();
+/**
+ * @param {ThemeId | null} themeId
+ */
+async function prepareForm(themeId) {
+  const { themeSelect } = await getThemeSettingsForm();
 
-  themeSelectLight?.addEventListener("click", () => setTheme("light"));
-  themeSelectDark?.addEventListener("click", () => setTheme("dark"));
+  if (themeSelect && themeId) {
+    themeSelect.value = themeId;
+  }
+
+  themeSelect?.addEventListener("change", (event) => {
+    const { target } = event;
+    const value = target instanceof HTMLSelectElement && target.value;
+
+    if (isThemeId(value)) {
+      setTheme(value);
+    }
+  });
 }
 
 /**
@@ -32,16 +45,22 @@ function setTheme(themeId) {
 }
 
 async function getThemeSettingsForm() {
-  const themeSelectLight = await getIncludedElement(
-    "#theme-select-light",
+  const themeSelect = await getIncludedElement(
+    "#theme-select",
     "#include-settings",
-    HTMLButtonElement
-  );
-  const themeSelectDark = await getIncludedElement(
-    "#theme-select-dark",
-    "#include-settings",
-    HTMLButtonElement
+    HTMLSelectElement
   );
 
-  return { themeSelectLight, themeSelectDark };
+  return { themeSelect };
+}
+
+/**
+ *
+ * @param {unknown} value
+ * @returns {value is ThemeId}
+ */
+function isThemeId(value) {
+  return (
+    typeof value === "string" && ["light", "dark", "system"].includes(value)
+  );
 }

--- a/src/base/scripts/theme.js
+++ b/src/base/scripts/theme.js
@@ -1,7 +1,47 @@
-function ThemeCheck() {
-    if (localStorage.getItem('theme') === 'light') {
-        document.body.classList.add('theme-is-light')
-    } else {
-        document.body.classList.add('theme-is-dark')
-    }
+/**
+ * @typedef {Parameters<typeof window.api.setTheme>[0]} ThemeId
+ */
+
+const THEME_STORE_KEY = "theme";
+
+window.addEventListener("DOMContentLoaded", () => {
+  const themeId = /** @type {ThemeId | null} */ (
+    localStorage.getItem(THEME_STORE_KEY)
+  );
+
+  if (themeId) {
+    setTheme(themeId);
+  }
+
+  prepareForm();
+});
+
+async function prepareForm() {
+  const { themeSelectLight, themeSelectDark } = await getThemeSettingsForm();
+
+  themeSelectLight?.addEventListener("click", () => setTheme("light"));
+  themeSelectDark?.addEventListener("click", () => setTheme("dark"));
+}
+
+/**
+ * @param {ThemeId} themeId
+ */
+function setTheme(themeId) {
+  localStorage.setItem(THEME_STORE_KEY, themeId);
+  window.api.setTheme(themeId);
+}
+
+async function getThemeSettingsForm() {
+  const themeSelectLight = await getIncludedElement(
+    "#theme-select-light",
+    "#include-settings",
+    HTMLButtonElement
+  );
+  const themeSelectDark = await getIncludedElement(
+    "#theme-select-dark",
+    "#include-settings",
+    HTMLButtonElement
+  );
+
+  return { themeSelectLight, themeSelectDark };
 }

--- a/src/base/scripts/theme.js
+++ b/src/base/scripts/theme.js
@@ -40,9 +40,16 @@ async function prepareForm(themeSetting) {
     const value = target instanceof HTMLSelectElement && target.value;
 
     if (isThemeSetting(value)) {
-      currentThemeSetting = value;
+      const isTabTheme = value === "tab";
 
+      currentThemeSetting = value;
       localStorage.setItem(THEME_STORE_KEY, value);
+
+      if (isTabTheme) {
+        requestTabTheme();
+        return;
+      }
+
       setTheme(value);
     } else {
       currentThemeSetting = null;

--- a/src/base/scripts/webviews/preload.js
+++ b/src/base/scripts/webviews/preload.js
@@ -1,5 +1,7 @@
 // @ts-nocheck The file requires a review, before dedicating time to add quality types.
 
+const { ipcRenderer } = require("electron");
+
 // Set the title of the tab name
 /// Instead of the tab name being "PROJECT_NAME - Penpot", this script will remove the " - Penpot" portion.
 function SetTitleToDash() {
@@ -78,3 +80,39 @@ window.onload = function() {
         };
     }
 };
+
+// Theme
+window.addEventListener("DOMContentLoaded", () =>
+  onClassChange(document.body, () => dispatchThemeUpdate())
+);
+
+ipcRenderer.on("theme-request-update", () => dispatchThemeUpdate());
+
+/**
+ * Observes a node and executes a callback on a class change.
+ * 
+ * @param {Parameters<MutationObserver["observe"]>[0]} node
+ * @param {function} callback
+ */
+function onClassChange(node, callback) {
+  const observer = new MutationObserver((mutations) => {
+    const hasClassChanged = mutations.some(
+      ({ type, attributeName }) =>
+        type === "attributes" && attributeName === "class"
+    );
+
+    if (hasClassChanged) {
+      callback();
+    }
+  });
+
+  observer.observe(node, { attributes: true });
+}
+
+/**
+ * Sends an event, with a currently set theme, to the webview's host.
+ */
+function dispatchThemeUpdate() {
+  const isLightTheme = document.body.classList.contains("light");
+  ipcRenderer.sendToHost("theme-update", isLightTheme ? "light" : "dark");
+}

--- a/src/base/styles/index.css
+++ b/src/base/styles/index.css
@@ -12,14 +12,17 @@
 }
 
 @media (prefers-color-scheme: light) {
-  body {
+  :root { 
     --theme-filter: invert(1);
+  }
 
+  body, #settings {
     background: #ffffff;
   }
 
   .titlebar,
-  .controls {
+  .controls,
+  #settings > * {
     filter: var(--theme-filter, none);
   }
 
@@ -141,7 +144,6 @@ drag {
   margin: 6px;
   min-width: 250px;
   width: 300px;
-  transition: 1s all;
 
   div:nth-child(1) > div.settings-section-header {
     border-radius: 4px 4px 0px 0px;

--- a/src/base/styles/index.css
+++ b/src/base/styles/index.css
@@ -12,11 +12,12 @@
 }
 
 @media (prefers-color-scheme: light) {
-  :root { 
+  :root {
     --theme-filter: invert(1);
   }
 
-  body, #settings {
+  body,
+  #settings {
     background: #ffffff;
   }
 
@@ -163,11 +164,24 @@ drag {
     display: flex;
     margin: 12px;
 
-    input {
+    input,
+    select {
       padding: 6px 12px;
       border-radius: 4px;
       border: 1px #656565 solid;
       margin-right: 6px;
+    }
+
+    select {
+      width: 100%;
+      background: rgb(18, 18, 18);
+
+      @media (prefers-color-scheme: light) {
+        option {
+          background: rgb(237, 237, 237);
+          color: black;
+        }
+      }
     }
 
     input#instance-save {
@@ -184,28 +198,6 @@ div#theme {
   display: flex;
   justify-content: space-evenly;
   gap: 12px;
-}
-
-.theme-selection {
-  border: 2px #7d7d7d solid;
-  border-radius: 10px;
-  padding: 12px 32px;
-  width: 100%;
-  text-align: center;
-
-  p {
-    margin: 0px;
-  }
-}
-
-#theme-select-light {
-  color: black;
-  background: white;
-}
-
-#theme-select-dark {
-  color: white;
-  background: #232222;
 }
 
 .settings-section-content a {

--- a/src/base/styles/index.css
+++ b/src/base/styles/index.css
@@ -11,12 +11,15 @@
   border: 0;
 }
 
-.theme-is-light {
-  --theme-filter: invert(1);
+@media (prefers-color-scheme: light) {
+  body {
+    --theme-filter: invert(1);
 
-  background: #ffffff;
+    background: #ffffff;
+  }
 
-  .titlebar, .controls {
+  .titlebar,
+  .controls {
     filter: var(--theme-filter, none);
   }
 
@@ -26,8 +29,10 @@
   }
 }
 
-.theme-is-dark {
-  background: #18181a;
+@media (prefers-color-scheme: dark) {
+  body {
+    background: #18181a;
+  }
 
   #theme-select-dark {
     border-color: #00ff89;
@@ -191,12 +196,12 @@ div#theme {
   }
 }
 
-div#theme-select-light {
+#theme-select-light {
   color: black;
   background: white;
 }
 
-div#theme-select-dark {
+#theme-select-dark {
   color: white;
   background: #232222;
 }

--- a/src/base/styles/index.css
+++ b/src/base/styles/index.css
@@ -12,10 +12,12 @@
 }
 
 .theme-is-light {
+  --theme-filter: invert(1);
+
   background: #ffffff;
 
-  .titlebar {
-    filter: invert(1);
+  .titlebar, .controls {
+    filter: var(--theme-filter, none);
   }
 
   #theme-select-light {

--- a/src/process/global.d.ts
+++ b/src/process/global.d.ts
@@ -1,13 +1,15 @@
+type Electron = import("electron");
+
 declare var api: {
   send: (channel: string, data: unknown) => void;
-  setTheme: (themeId: "light" | "dark" | "system") => void;
+  setTheme: (themeId: Electron.NativeTheme["themeSource"]) => void;
   onOpenTab: (callback: (href: string) => void) => void;
   onTabMenuAction: (
     callback: ({ command: string, tabId: number }) => void
   ) => void;
 };
 
-declare var mainWindow: import("electron").BrowserWindow;
+declare var mainWindow: Electron.BrowserWindow;
 
 declare var transparent: boolean;
 declare var AppIcon: string;

--- a/src/process/global.d.ts
+++ b/src/process/global.d.ts
@@ -1,5 +1,6 @@
 declare var api: {
   send: (channel: string, data: unknown) => void;
+  setTheme: (themeId: "light" | "dark" | "system") => void;
   onOpenTab: (callback: (href: string) => void) => void;
   onTabMenuAction: (
     callback: ({ command: string, tabId: number }) => void

--- a/src/process/preload.js
+++ b/src/process/preload.js
@@ -21,6 +21,9 @@ contextBridge.exposeInMainWorld(
         ipcRenderer.send(channel, data);
       }
     },
+    setTheme: (themeId) => {
+      ipcRenderer.send("set-theme", themeId);
+    },
     onOpenTab: (callback) =>
       ipcRenderer.on("open-tab", (_event, value) => callback(value)),
     onTabMenuAction: (callback) =>

--- a/src/process/window.js
+++ b/src/process/window.js
@@ -1,4 +1,4 @@
-const {app, BrowserWindow, ipcMain, ipcRenderer, shell} = require('electron')
+const {app, BrowserWindow, ipcMain, ipcRenderer, shell, nativeTheme} = require('electron')
 const windowStateKeeper = require('electron-window-state')
 const path = require('path')
 
@@ -55,6 +55,9 @@ module.exports = {
         window: mainWindow
       })
     })
+    ipcMain.on("set-theme", (_event, themeId) => {
+      nativeTheme.themeSource = themeId;
+    });
 
     if (process.platform === 'darwin') {
       // Move Tabs when entering or existing fullscreen on macOS


### PR DESCRIPTION
Added the theme setting. It changes user interface's colour scheme between light and dark.

Available options are:
- Light - hard sets UI to the light theme,
- Dark - hard sets UI to the dark theme,
- System - sets UI to follow OS theme,
- Penpot - sets UI to follow a theme of the penpot app in the active tab. 