### PR TITLE
feat: add multiple instances

### DIFF
--- a/package-lock.json
+++ b/package-lock.json
@@ -12,7 +12,8 @@
 				"@shoelace-style/shoelace": "^2.20.0",
 				"electron-tabs": "^1.0.1",
 				"electron-updater": "^6.3.9",
-				"electron-window-state": "^5.0.3"
+				"electron-window-state": "^5.0.3",
+				"zod": "^3.24.2"
 			},
 			"devDependencies": {
 				"@commitlint/cli": "^19.7.1",
@@ -8289,6 +8290,15 @@
 			},
 			"engines": {
 				"node": ">= 10"
+			}
+		},
+		"node_modules/zod": {
+			"version": "3.24.2",
+			"resolved": "https://registry.npmjs.org/zod/-/zod-3.24.2.tgz",
+			"integrity": "sha512-lY7CDW43ECgW9u1TcT3IoXHflywfVqDYze4waEz812jR/bZ8FHDsl7pFQoSZTz5N+2NqRXs8GBwnAwo3ZNxqhQ==",
+			"license": "MIT",
+			"funding": {
+				"url": "https://github.com/sponsors/colinhacks"
 			}
 		}
 	}

--- a/package.json
+++ b/package.json
@@ -37,7 +37,8 @@
 		"@shoelace-style/shoelace": "^2.20.0",
 		"electron-tabs": "^1.0.1",
 		"electron-updater": "^6.3.9",
-		"electron-window-state": "^5.0.3"
+		"electron-window-state": "^5.0.3",
+		"zod": "^3.24.2"
 	},
 	"devDependencies": {
 		"@commitlint/cli": "^19.7.1",

--- a/src/base/components/editableText.js
+++ b/src/base/components/editableText.js
@@ -1,0 +1,182 @@
+export class EditableText extends HTMLElement {
+	static observedAttributes = ["label", "placeholder"];
+
+	constructor() {
+		super();
+
+		this.attachShadow({ mode: "open" });
+
+		const template = document.createElement("template");
+		template.innerHTML = `
+			<style>
+				.visually-hidden {
+					clip: rect(0 0 0 0);
+					clip-path: inset(50%);
+					height: 1px;
+					width: 1px;
+					overflow: hidden;
+					position: absolute;
+					white-space: nowrap;
+				}
+
+				:host {
+					display: block;
+				}
+
+				div {
+					min-height: 1rem;
+					cursor: pointer;
+				}
+
+				input {
+					display: none;
+				}
+			</style>
+
+			<div part="text" tabindex="0"><slot></slot></div>
+			<label part="label" for="input" class="visually-hidden"></label>
+			<input part="input" id="input" type="text" />
+  	`;
+
+		this.currentText = "";
+
+		const structure = template.content.cloneNode(true);
+		this.shadowRoot?.appendChild(structure);
+
+		this.textElement = this.shadowRoot?.querySelector("div");
+		this.labelElement = this.shadowRoot?.querySelector("label");
+		this.inputElement = this.shadowRoot?.querySelector("input");
+
+		this.textElement?.addEventListener("click", () => this.edit());
+		this.textElement?.addEventListener("keydown", (event) => {
+			const isEnter = event.key === "Enter";
+			if (isEnter) {
+				this.edit();
+			}
+		});
+
+		this.inputElement?.addEventListener("blur", () => this.save());
+		this.inputElement?.addEventListener("keydown", (event) => {
+			const isEnter = event.key === "Enter";
+			if (isEnter) {
+				this.save();
+			}
+		});
+	}
+
+	connectedCallback() {
+		const slot = this.shadowRoot?.querySelector("slot");
+		const assignedNodes = slot?.assignedNodes();
+		const slotText =
+			(assignedNodes && assignedNodes[0]?.textContent?.trim()) || "";
+		this.currentText = slotText;
+
+		if (this.textElement) {
+			this.textElement.textContent = this.currentText;
+		}
+
+		if (!this.currentText) {
+			this.showView("input");
+		}
+	}
+
+	get label() {
+		return this.getAttribute("label");
+	}
+
+	set label(value) {
+		if (value) {
+			this.setAttribute("label", value);
+		} else {
+			this.removeAttribute("label");
+		}
+	}
+
+	get placeholder() {
+		return this.getAttribute("placeholder");
+	}
+
+	set placeholder(value) {
+		if (value) {
+			this.setAttribute("placeholder", value);
+		} else {
+			this.removeAttribute("placeholder");
+		}
+	}
+
+	/**
+	 * @param {string} name
+	 * @param {string} oldValue
+	 * @param {string} newValue
+	 */
+	attributeChangedCallback(name, oldValue, newValue) {
+		const isLabelChange = name === "label";
+		if (isLabelChange && this.labelElement) {
+			this.labelElement.textContent = newValue;
+			return;
+		}
+
+		const isPlaceholderChange = name === "placeholder";
+		if (isPlaceholderChange && this.inputElement) {
+			this.inputElement.placeholder = newValue;
+			return;
+		}
+	}
+
+	edit() {
+		if (!this.textElement || !this.inputElement) {
+			return;
+		}
+
+		this.inputElement.value = this.currentText;
+
+		this.showView("input");
+		this.inputElement.focus();
+	}
+
+	save() {
+		if (!this.textElement || !this.inputElement) {
+			return;
+		}
+
+		this.currentText = this.inputElement.value;
+		this.textElement.textContent = this.currentText;
+
+		if (!this.currentText) {
+			return;
+		}
+
+		const event = new CustomEvent("change", {
+			detail: { value: this.currentText },
+			bubbles: true,
+			composed: true,
+		});
+		this.dispatchEvent(event);
+
+		this.showView("text");
+		this.textElement.focus();
+	}
+
+	/**
+	 * Changes view between text and input.
+	 *
+	 * @param {'text' | 'input'} view
+	 */
+	showView(view) {
+		if (!this.textElement || !this.inputElement) {
+			return;
+		}
+
+		const shouldShowTextView = view === "text";
+		if (shouldShowTextView) {
+			this.inputElement.style.display = "none";
+			this.textElement.style.display = "block";
+			return;
+		}
+
+		this.textElement.style.display = "none";
+		this.inputElement.style.display = "block";
+	}
+}
+
+customElements.define("editable-text", EditableText);

--- a/src/base/components/settings.html
+++ b/src/base/components/settings.html
@@ -32,7 +32,7 @@
 </sl-drawer>
 
 <template id="template-instance-panel">
-	<div class="panel">
+	<div class="panel" tabindex="0">
 		<sl-color-picker size="small" format="hsl" opacity="true"></sl-color-picker>
 		<div class="body">
 			<editable-text

--- a/src/base/components/settings.html
+++ b/src/base/components/settings.html
@@ -1,17 +1,8 @@
 <sl-drawer id="settings" class="settings" placement="start" label="Settings">
-	<div>
-		<form id="instance-form" class="inline">
-			<sl-input
-				id="instance-field"
-				label="Instance"
-				type="url"
-				placeholder="https://design.penpot.app/"
-				size="small"
-			></sl-input>
-			<sl-button id="instance-save" type="submit" size="small">Save</sl-button>
-		</form>
-
-		<sl-select id="theme-select" label="Theme" size="small">
+	<div class="titled-section">
+		<h3>Theme</h3>
+		<sl-select id="theme-select" size="small">
+			<sl-visually-hidden slot="label">Theme</sl-visually-hidden>
 			<sl-option value="light">Light</sl-option>
 			<sl-option value="dark">Dark</sl-option>
 			<sl-option value="system">System</sl-option>
@@ -19,8 +10,35 @@
 		</sl-select>
 	</div>
 
-	<sl-button-group class="footer" label="Help Center">
+	<div class="titled-section">
+		<h3>Instances</h3>
+		<div id="instance-list" class="panel-list">
+			<sl-button id="instance-add" variant="default" size="small">
+				<sl-icon
+					slot="prefix"
+					name="plus-square"
+					label="Add instance"
+				></sl-icon>
+				Add instance
+			</sl-button>
+		</div>
+	</div>
+
+	<sl-button-group slot="footer" label="Help Center">
 		<sl-button id="open-docs" href="#" size="small">Documentation</sl-button>
 		<sl-button id="open-selfhost" href="#" size="small">Selfhost</sl-button>
 	</sl-button-group>
 </sl-drawer>
+
+<template id="template-instance-panel">
+	<div class="panel">
+		<sl-color-picker size="small"></sl-color-picker>
+		<div class="body">
+			<p class="label"></p>
+			<p class="hint"></p>
+		</div>
+		<sl-button variant="default" size="small">
+			<sl-icon slot="prefix" name="trash" label="Delete"></sl-icon>
+		</sl-button>
+	</div>
+</template>

--- a/src/base/components/settings.html
+++ b/src/base/components/settings.html
@@ -12,7 +12,8 @@
 
 	<div class="titled-section">
 		<h3>Instances</h3>
-		<div id="instance-list" class="panel-list">
+		<div class="panel-list">
+			<div id="instance-list" class="list"></div>
 			<sl-button id="instance-add" variant="default" size="small">
 				<sl-icon
 					slot="prefix"

--- a/src/base/components/settings.html
+++ b/src/base/components/settings.html
@@ -33,10 +33,18 @@
 
 <template id="template-instance-panel">
 	<div class="panel">
-		<sl-color-picker size="small"></sl-color-picker>
+		<sl-color-picker size="small" format="hsl" opacity="true"></sl-color-picker>
 		<div class="body">
-			<p class="label"></p>
-			<p class="hint"></p>
+			<editable-text
+				class="label"
+				label="Label"
+				placeholder="My instance"
+			></editable-text>
+			<editable-text
+				class="hint"
+				label="Origin"
+				placeholder="https://my-penpot.example.com"
+			></editable-text>
 		</div>
 		<sl-button variant="default" size="small">
 			<sl-icon slot="prefix" name="trash" label="Delete"></sl-icon>

--- a/src/base/components/tabs.html
+++ b/src/base/components/tabs.html
@@ -47,16 +47,14 @@
 			height: 80%;
 			min-height: 32px;
 			transition: 0.4s border;
-			border: 1px transparent solid !important;
+			border: 1px var(--tab-accent-color, transparent) solid !important;
 		}
 		.tab:not(.active):hover {
 			background: #3f4247 !important;
 			color: white !important;
-			border: 1px rgba(255, 255, 255, 0.2) solid !important;
 		}
 		.tab.active {
 			padding: 5px 10px;
-			border: 1px rgba(255, 255, 255, 0.1) solid !important;
 			transition: 0.4s border;
 		}
 		.tab.visible:not(.active) + .tab.visible:not(.active) {

--- a/src/base/components/tabs.html
+++ b/src/base/components/tabs.html
@@ -35,7 +35,7 @@
 			width: calc(100% - var(--navBarWF));
 			filter: var(--theme-filter, none);
 
-			margin-left: 4rem;
+			margin-left: 4.5rem;
 		}
 		.tab {
 			-webkit-app-region: no-drag;

--- a/src/base/index.html
+++ b/src/base/index.html
@@ -25,6 +25,10 @@
 			src="./components/settings.html"
 		></sl-include>
 
+		<div id="context-menu" class="context-menu">
+			<sl-menu class="menu"></sl-menu>
+		</div>
+
 		<div class="no-tabs-exist" style="display: none">
 			<img src="./assets/penpot-logo/logo-white.png" />
 			<h2>No tabs are opened</h2>

--- a/src/base/index.html
+++ b/src/base/index.html
@@ -29,7 +29,7 @@
 			<sl-menu class="menu"></sl-menu>
 		</div>
 
-		<div class="no-tabs-exist" style="display: none">
+		<div class="no-tabs-exist">
 			<img src="./assets/penpot-logo/logo-white.png" />
 			<h2>No tabs are opened</h2>
 			<p>Add a new tab to start making awesome things.</p>

--- a/src/base/scripts/contextMenu.js
+++ b/src/base/scripts/contextMenu.js
@@ -1,0 +1,82 @@
+import {
+	SlMenu,
+	SlMenuItem,
+} from "../../../node_modules/@shoelace-style/shoelace/cdn/shoelace.js";
+import { typedQuerySelector } from "./dom.js";
+
+/**
+ * @typedef {Object} MenuItem
+ * @property {string} label
+ * @property {Function} onClick
+ */
+
+/** @type {ResizeObserver | null} */
+let resizeObserver;
+
+/**
+ * Opens a context menu with given items, positioned "relatively" to a host element.
+ *
+ * @param {Element} host
+ * @param {MenuItem[]} items
+ */
+export function showContextMenu(host, items) {
+	const { contextMenu, menu } = getContextMenuElement();
+	if (!contextMenu || !menu) {
+		return;
+	}
+
+	const menuItems = items.map(createContextMenuItem);
+	menu.replaceChildren(...menuItems);
+
+	// By default the menu has display set to `none`.
+	// Position calculation has to be delayed until the menu is part of the DOM. Otherwise the menu's size and position are reported as 0.
+	resizeObserver = new ResizeObserver(() => {
+		const {
+			top: hostTop,
+			left: hostLeft,
+			height: hostHeight,
+			width: hostWidth,
+		} = host.getBoundingClientRect();
+		const { width: menuWidth } = menu.getBoundingClientRect();
+		menu.style.top = `${hostTop + hostHeight + 4}`;
+		menu.style.left = `${hostLeft + hostWidth - menuWidth}`;
+	});
+	resizeObserver.observe(menu);
+
+	contextMenu.addEventListener("click", hideContextMenu);
+	contextMenu.classList.add("visible");
+}
+
+export function hideContextMenu() {
+	const { contextMenu, menu } = getContextMenuElement();
+	if (!contextMenu || !menu) {
+		return;
+	}
+
+	contextMenu?.classList.remove("visible");
+	contextMenu.removeEventListener("click", hideContextMenu);
+	resizeObserver?.unobserve(menu);
+}
+
+/**
+ * Creates a menu item element.
+ *
+ * @param {MenuItem} item
+ */
+function createContextMenuItem({ label, onClick }) {
+	const menuItem = new SlMenuItem();
+	menuItem.innerText = label;
+	menuItem.addEventListener("click", (event) => {
+		event.stopPropagation();
+		onClick();
+	});
+
+	return menuItem;
+}
+
+function getContextMenuElement() {
+	const contextMenu = typedQuerySelector("#context-menu", HTMLDivElement);
+	const menu = typedQuerySelector("sl-menu.menu", SlMenu, contextMenu);
+
+	return { contextMenu, menu };
+}

--- a/src/base/scripts/electron-tabs.js
+++ b/src/base/scripts/electron-tabs.js
@@ -38,7 +38,11 @@ export async function initTabs() {
 	window.api.onOpenTab(openTab);
 	window.api.onTabMenuAction(handleTabMenuAction);
 
-	const addTabButton = tabGroup?.shadow.querySelector(".buttons > button");
+	const addTabButton = typedQuerySelector(
+		".buttons > button",
+		HTMLButtonElement,
+		tabGroup?.shadow,
+	);
 	addTabButton?.addEventListener("contextmenu", async () => {
 		const instances = await window.api.getSetting("instances");
 		const hasMultipleInstances = instances.length > 1;

--- a/src/base/scripts/electron-tabs.js
+++ b/src/base/scripts/electron-tabs.js
@@ -1,6 +1,6 @@
+import { DEFAULT_INSTANCE } from "../../shared/instance.js";
 import { hideContextMenu, showContextMenu } from "./contextMenu.js";
 import { getIncludedElement, typedQuerySelector } from "./dom.js";
-import { DEFAULT_INSTANCE } from "./instance.js";
 import { handleInTabThemeUpdate, THEME_TAB_EVENTS } from "./theme.js";
 
 /**

--- a/src/base/scripts/electron-tabs.js
+++ b/src/base/scripts/electron-tabs.js
@@ -10,6 +10,7 @@ import { handleInTabThemeUpdate, THEME_TAB_EVENTS } from "./theme.js";
  *
  * @typedef {Object} TabOptions
  * @property {string =} accentColor
+ * @property {string =} partition
  */
 
 const PRELOAD_PATH = "./scripts/webviews/preload.mjs";
@@ -51,10 +52,10 @@ export async function initTabs() {
 			return;
 		}
 
-		const menuItems = instances.map(({ origin, label, color }) => ({
+		const menuItems = instances.map(({ id, origin, label, color }) => ({
 			label: label || origin,
 			onClick: () => {
-				openTab(origin, { accentColor: color });
+				openTab(origin, { accentColor: color, partition: id });
 				hideContextMenu();
 			},
 		}));
@@ -67,12 +68,16 @@ export async function initTabs() {
  * @param {string =} href
  * @param {TabOptions} options
  */
-export async function setDefaultTab(href, { accentColor } = {}) {
+export async function setDefaultTab(href, { accentColor, partition } = {}) {
 	const tabGroup = await getTabGroup();
 
 	tabGroup?.setDefaultTab({
 		...DEFAULT_TAB_OPTIONS,
 		...(href ? { src: href } : {}),
+		webviewAttributes: {
+			...DEFAULT_TAB_OPTIONS.webviewAttributes,
+			...(partition && { partition: `persist:${partition}` }),
+		},
 		ready: (tab) => tabReadyHandler(tab, { accentColor }),
 	});
 }
@@ -81,7 +86,7 @@ export async function setDefaultTab(href, { accentColor } = {}) {
  * @param {string =} href
  * @param {TabOptions} options
  */
-export async function openTab(href, { accentColor } = {}) {
+export async function openTab(href, { accentColor, partition } = {}) {
 	const tabGroup = await getTabGroup();
 
 	tabGroup?.addTab(
@@ -89,6 +94,10 @@ export async function openTab(href, { accentColor } = {}) {
 			? {
 					...DEFAULT_TAB_OPTIONS,
 					src: href,
+					webviewAttributes: {
+						...DEFAULT_TAB_OPTIONS.webviewAttributes,
+						...(partition && { partition: `persist:${partition}` }),
+					},
 					ready: (tab) => {
 						tabReadyHandler(tab, { accentColor });
 					},

--- a/src/base/scripts/electron-tabs.js
+++ b/src/base/scripts/electron-tabs.js
@@ -1,5 +1,6 @@
 import { hideContextMenu, showContextMenu } from "./contextMenu.js";
 import { getIncludedElement, typedQuerySelector } from "./dom.js";
+import { DEFAULT_INSTANCE } from "./instance.js";
 import { handleInTabThemeUpdate, THEME_TAB_EVENTS } from "./theme.js";
 
 /**
@@ -11,10 +12,9 @@ import { handleInTabThemeUpdate, THEME_TAB_EVENTS } from "./theme.js";
  * @property {string =} accentColor
  */
 
-const DEFAULT_INSTANCE = "https://design.penpot.app/";
 const PRELOAD_PATH = "./scripts/webviews/preload.mjs";
 const DEFAULT_TAB_OPTIONS = Object.freeze({
-	src: DEFAULT_INSTANCE,
+	src: DEFAULT_INSTANCE.origin,
 	active: true,
 	webviewAttributes: {
 		preload: PRELOAD_PATH,

--- a/src/base/scripts/electron-tabs.js
+++ b/src/base/scripts/electron-tabs.js
@@ -59,12 +59,6 @@ export async function initTabs() {
 	});
 }
 
-export async function resetTabs() {
-	const tabGroup = await getTabGroup();
-	tabGroup?.eachTab((tab) => tab.close(false));
-	openTab();
-}
-
 /**
  * @param {string =} href
  * @param {TabOptions} options

--- a/src/base/scripts/instance.js
+++ b/src/base/scripts/instance.js
@@ -7,17 +7,12 @@ import {
 import { isNonNull } from "../../tools/value.js";
 import { isParentNode } from "../../tools/element.js";
 import { EditableText } from "../components/editableText.js";
+import { DEFAULT_INSTANCE } from "../../shared/instance.js";
 
 /**
  * @typedef {Awaited<ReturnType<typeof window.api.getSetting<"instances">>>} Instances
  */
 
-export const DEFAULT_INSTANCE = Object.freeze({
-	origin: "https://design.penpot.app",
-	label: "Official",
-	color: "hsla(0,0,0,0)",
-	isDefault: false,
-});
 const INSTANCE_EVENTS = Object.freeze({
 	REGISTER: "registerInstance",
 	REMOVE: "removeInstance",
@@ -27,9 +22,7 @@ export async function initInstance() {
 	const instances = await window.api.getSetting("instances");
 
 	const { origin, color } =
-		instances.find(({ isDefault }) => isDefault) ||
-		instances[0] ||
-		DEFAULT_INSTANCE;
+		instances.find(({ isDefault }) => isDefault) || instances[0];
 
 	await setDefaultTab(origin, {
 		accentColor: color,

--- a/src/base/scripts/instance.js
+++ b/src/base/scripts/instance.js
@@ -21,7 +21,7 @@ import {
 export async function initInstance() {
 	const instances = await window.api.getSetting("instances");
 
-	const { origin, color } =
+	const { id, origin, color } =
 		instances.find(({ isDefault }) => isDefault) || instances[0];
 
 	await setDefaultTab(origin, {
@@ -29,6 +29,7 @@ export async function initInstance() {
 	});
 	openTab(origin, {
 		accentColor: color,
+		partition: id,
 	});
 
 	updateInstanceList();
@@ -145,6 +146,7 @@ function createInstancePanel(instance, template) {
 					onClick: () => {
 						setDefaultTab(origin, {
 							accentColor: color,
+							partition: id,
 						});
 						window.api.send(INSTANCE_EVENTS.SET_DEFAULT, id);
 						hideContextMenu();

--- a/src/base/scripts/instance.js
+++ b/src/base/scripts/instance.js
@@ -12,11 +12,17 @@ const INSTANCE_EVENTS = Object.freeze({
 
 export async function initInstance() {
 	const instances = await window.api.getSetting("instances");
-	const { origin } = instances[0] || {};
 
-	await setDefaultTab(origin);
-	openTab(origin);
+	const { origin, color } =
+		instances.find(({ isDefault }) => isDefault) || instances[0] || {};
+
+	await setDefaultTab(origin, {
+		accentColor: color,
+	});
 	prepareForm(origin);
+	openTab(origin, {
+		accentColor: color,
+	});
 }
 
 /**

--- a/src/base/scripts/main.js
+++ b/src/base/scripts/main.js
@@ -1,4 +1,5 @@
 import "../../../node_modules/@shoelace-style/shoelace/cdn/shoelace.js";
+import { setBasePath } from "../../../node_modules/@shoelace-style/shoelace/cdn/utilities/base-path.js";
 import "../../../node_modules/electron-tabs/dist/electron-tabs.js";
 
 import { initTabs } from "./electron-tabs.js";
@@ -6,6 +7,8 @@ import { initInstance } from "./instance.js";
 import { initSettings } from "./settings.js";
 import { initTheme } from "./theme.js";
 import { initToggles } from "./toggles.js";
+
+setBasePath("../../node_modules/@shoelace-style/shoelace/cdn");
 
 window.addEventListener("DOMContentLoaded", () => {
 	initTabs();

--- a/src/base/scripts/main.js
+++ b/src/base/scripts/main.js
@@ -2,6 +2,8 @@ import "../../../node_modules/@shoelace-style/shoelace/cdn/shoelace.js";
 import { setBasePath } from "../../../node_modules/@shoelace-style/shoelace/cdn/utilities/base-path.js";
 import "../../../node_modules/electron-tabs/dist/electron-tabs.js";
 
+import "../components/editableText.js";
+
 import { initTabs } from "./electron-tabs.js";
 import { initInstance } from "./instance.js";
 import { initSettings } from "./settings.js";

--- a/src/base/scripts/settings.js
+++ b/src/base/scripts/settings.js
@@ -16,11 +16,7 @@ export async function initSettings() {
 }
 
 async function toggleSettings() {
-	const settingsDrawer = await getIncludedElement(
-		"#settings",
-		"#include-settings",
-		SlDrawer,
-	);
+	const { settingsDrawer } = await getSettingsElements();
 
 	if (settingsDrawer?.open) {
 		settingsDrawer?.hide();
@@ -28,6 +24,18 @@ async function toggleSettings() {
 	}
 
 	settingsDrawer?.show();
+}
+
+export async function disableSettingsFocusTrap() {
+	const { settingsDrawer } = await getSettingsElements();
+
+	settingsDrawer?.modal.activateExternal();
+}
+
+export async function enableSettingsFocusTrap() {
+	const { settingsDrawer } = await getSettingsElements();
+
+	settingsDrawer?.modal.deactivateExternal();
 }
 
 async function getTriggers() {
@@ -48,4 +56,14 @@ async function getTriggers() {
 	);
 
 	return { toggleSettingsButton, openDocsButton, openSelfhostButton };
+}
+
+async function getSettingsElements() {
+	const settingsDrawer = await getIncludedElement(
+		"#settings",
+		"#include-settings",
+		SlDrawer,
+	);
+
+	return { settingsDrawer };
 }

--- a/src/base/scripts/ui.js
+++ b/src/base/scripts/ui.js
@@ -1,0 +1,47 @@
+/**
+ * Creates a focus trap between a range of elements.
+ *
+ * @param {Array<HTMLElement>} items - Range of elements to trap the focus between.
+ *
+ * @returns {Function} Destroy the focus trap.
+ */
+export function trapFocus(items) {
+	const firstElement = items[0];
+	const lastElement = items[items.length - 1];
+
+	firstElement.addEventListener("keydown", handleKeyDown);
+	lastElement.addEventListener("keydown", handleKeyDown);
+
+	/**
+	 * @param {KeyboardEvent} event
+	 */
+	function handleKeyDown(event) {
+		const { key, shiftKey } = event;
+		const isTabKey = key === "Tab";
+		const isLoopForward =
+			isTabKey && document.activeElement === lastElement && !shiftKey;
+		const isLoopBackward =
+			isTabKey && document.activeElement === firstElement && shiftKey;
+		const isLoop = isLoopBackward || isLoopForward;
+
+		if (!isLoop) {
+			return;
+		}
+
+		event.preventDefault();
+
+		if (isLoopForward) {
+			firstElement.focus();
+			return;
+		}
+
+		if (isLoopBackward) {
+			lastElement.focus();
+		}
+	}
+
+	return () => {
+		firstElement.removeEventListener("keydown", handleKeyDown);
+		lastElement.removeEventListener("keydown", handleKeyDown);
+	};
+}

--- a/src/base/styles/index.css
+++ b/src/base/styles/index.css
@@ -1,6 +1,7 @@
 @import url("./form.css");
 @import url("./controls.css");
 @import url("./settings.css");
+@import url("./menu.css");
 
 @media (prefers-color-scheme: light) {
 	:root {

--- a/src/base/styles/index.css
+++ b/src/base/styles/index.css
@@ -1,3 +1,6 @@
+@import url("./normalize.css");
+@import url("./theme.css");
+@import url("./layout.css");
 @import url("./form.css");
 @import url("./controls.css");
 @import url("./settings.css");
@@ -59,6 +62,7 @@ drag {
 }
 
 .no-tabs-exist {
+	display: none;
 	position: fixed;
 	top: 50%;
 	left: 50%;
@@ -68,9 +72,18 @@ drag {
 
 	img {
 		width: 54px;
+		margin: auto;
+	}
+
+	h2 {
+		margin: var(--sl-spacing-medium) auto var(--sl-spacing-small);
+	}
+	p {
+		margin: var(--sl-spacing-small) auto;
 	}
 
 	button {
+		margin: var(--sl-spacing-medium) auto var(--sl-spacing-small);
 		color: black;
 		background: #00ff89;
 		border: none;

--- a/src/base/styles/layout.css
+++ b/src/base/styles/layout.css
@@ -1,0 +1,5 @@
+.titled-section {
+	display: flex;
+	flex-direction: column;
+	gap: var(--sl-spacing-x-small);
+}

--- a/src/base/styles/menu.css
+++ b/src/base/styles/menu.css
@@ -1,0 +1,18 @@
+.context-menu {
+	display: none;
+	position: absolute;
+	height: 100%;
+	width: 100%;
+	top: 0;
+	left: 0;
+	z-index: var(--sl-z-index-dialog);
+
+	&.visible {
+		display: block;
+	}
+
+	& .menu {
+		position: absolute;
+		max-width: 200px;
+	}
+}

--- a/src/base/styles/normalize.css
+++ b/src/base/styles/normalize.css
@@ -1,0 +1,30 @@
+:root {
+	font-synthesis: none;
+	text-rendering: optimizeLegibility;
+	-webkit-font-smoothing: antialiased;
+	-moz-osx-font-smoothing: grayscale;
+}
+
+*,
+*::before,
+*::after {
+	box-sizing: border-box;
+}
+
+* {
+	margin: 0;
+}
+
+img,
+picture,
+video {
+	display: block;
+	max-width: 100%;
+}
+
+input,
+button,
+textarea,
+select {
+	font: inherit;
+}

--- a/src/base/styles/settings.css
+++ b/src/base/styles/settings.css
@@ -25,8 +25,12 @@
 
 .panel-list {
 	display: grid;
-
 	row-gap: var(--sl-spacing-small);
+
+	.list {
+		display: grid;
+		row-gap: var(--sl-spacing-small);
+	}
 
 	> sl-button {
 		width: 100%;

--- a/src/base/styles/settings.css
+++ b/src/base/styles/settings.css
@@ -3,7 +3,8 @@
 
 	&::part(body) {
 		display: grid;
-		align-content: space-between;
+		align-content: start;
+		row-gap: var(--sl-spacing-large);
 	}
 
 	&::part(panel) {
@@ -16,8 +17,42 @@
 		box-shadow: unset;
 	}
 
-	.footer {
+	sl-button-group {
 		display: grid;
 		place-content: center;
+	}
+}
+
+.panel-list {
+	display: grid;
+
+	row-gap: var(--sl-spacing-small);
+
+	> sl-button {
+		width: 100%;
+	}
+}
+
+.panel {
+	display: grid;
+	grid-template-columns: min-content auto min-content;
+	align-items: center;
+
+	gap: var(--sl-spacing-small);
+	padding: var(--sl-spacing-2x-small) var(--sl-spacing-x-small);
+
+	background-color: var(--sl-color-neutral-0);
+	border: var(--sl-panel-border-width) var(--sl-panel-border-color) solid;
+
+	.label,
+	.hint {
+		margin: var(--sl-spacing-2x-small) auto;
+	}
+
+	.label {
+		font-size: var(--sl-font-size-small);
+	}
+	.hint {
+		font-size: var(--sl-font-size-x-small);
 	}
 }

--- a/src/base/styles/theme.css
+++ b/src/base/styles/theme.css
@@ -1,0 +1,7 @@
+sl-color-picker {
+	--sl-input-height-small: 16px;
+
+	&::part(trigger) {
+		border-radius: var(--sl-border-radius-medium);
+	}
+}

--- a/src/base/tsconfig.json
+++ b/src/base/tsconfig.json
@@ -3,5 +3,5 @@
 	"compilerOptions": {
 		"lib": ["ESNext", "DOM", "DOM.Iterable"]
 	},
-	"include": ["**/*", "../tools", "../types"]
+	"include": ["**/*", "../tools", "../types", "../shared"]
 }

--- a/src/process/navigation.js
+++ b/src/process/navigation.js
@@ -47,6 +47,10 @@ ipcMain.on(INSTANCE_EVENTS.REGISTER, (event, instance) => {
 });
 
 ipcMain.on(INSTANCE_EVENTS.REMOVE, (event, id) => {
+	const userDataPath = app.getPath("sessionData");
+	const partitionPath = join(userDataPath, "Partitions", id);
+
+	shell.trashItem(partitionPath);
 	settings.instances = settings.instances.filter(
 		({ id: registeredId }) => registeredId !== id,
 	);

--- a/src/process/navigation.js
+++ b/src/process/navigation.js
@@ -27,20 +27,19 @@ const ALLOWED_EXTERNAL_URLS = Object.freeze([
 ]);
 
 ipcMain.on("registerInstance", (event, instance) => {
-	try {
-		const { origin } = new URL(instance);
-		settings.instances = [{ origin }];
-	} catch (error) {
-		console.error(`[ERROR] [IPC.registerInstance] Failed with: ${instance}`);
+	const { origin } = instance;
+	const hasValidOrigin = URL.canParse(origin);
+	if (hasValidOrigin) {
+		settings.instances = [...settings.instances, instance];
+	} else {
+		console.warn(`[WARN] [IPC.registerInstance] Failed with: ${origin}`);
 	}
 });
 
-ipcMain.on("removeInstance", (event, instance) => {
-	try {
-		settings.instances = [];
-	} catch (error) {
-		console.error(`[ERROR] [IPC.removeInstance] Failed with: ${instance}`);
-	}
+ipcMain.on("removeInstance", (event, id) => {
+	settings.instances = settings.instances.filter(
+		({ id: registeredId }) => registeredId !== id,
+	);
 });
 
 app.on("web-contents-created", (event, contents) => {

--- a/src/process/navigation.js
+++ b/src/process/navigation.js
@@ -27,9 +27,21 @@ const ALLOWED_EXTERNAL_URLS = Object.freeze([
 ]);
 
 ipcMain.on("registerInstance", (event, instance) => {
-	const { origin } = instance;
+	const { id, origin } = instance;
 	const hasValidOrigin = URL.canParse(origin);
 	if (hasValidOrigin) {
+		const instanceIndex = settings.instances.findIndex(
+			({ id: registeredId }) => registeredId === id,
+		);
+		if (instanceIndex > -1) {
+			settings.instances = settings.instances.toSpliced(
+				instanceIndex,
+				1,
+				instance,
+			);
+			return;
+		}
+
 		settings.instances = [...settings.instances, instance];
 	} else {
 		console.warn(`[WARN] [IPC.registerInstance] Failed with: ${origin}`);

--- a/src/process/navigation.js
+++ b/src/process/navigation.js
@@ -5,13 +5,8 @@ import { toMultiline } from "./string.js";
 import { getMainWindow } from "./window.js";
 import { settings } from "./settings.js";
 
-// Covered origins and URLs are scoped to the Penpot Desktop app (e.g. Penpot instances that can be opened) and the Penpot web app (e.g. links in the Menu > Help & info).
-const OFFICIAL_INSTANCE_ORIGINS = Object.freeze([
-	"https://design.penpot.app",
-	"https://early.penpot.dev",
-]);
+// Covered origins and URLs are scoped to the Penpot web app (e.g. links in the Menu > Help & info).
 const ALLOWED_INTERNAL_ORIGINS = Object.freeze([
-	...OFFICIAL_INSTANCE_ORIGINS,
 	"https://penpot.app",
 	"https://help.penpot.app",
 ]);
@@ -144,10 +139,7 @@ app.on("web-contents-created", (event, contents) => {
 			console.log("Clear non-instance origins data.");
 
 			contents.session.clearData({
-				excludeOrigins: [
-					...OFFICIAL_INSTANCE_ORIGINS,
-					...getUserInstanceOrigins(settings),
-				],
+				excludeOrigins: [...getUserInstanceOrigins(settings)],
 			});
 		}
 	});

--- a/src/process/navigation.js
+++ b/src/process/navigation.js
@@ -4,6 +4,7 @@ import { join } from "path";
 import { toMultiline } from "./string.js";
 import { getMainWindow } from "./window.js";
 import { settings } from "./settings.js";
+import { INSTANCE_EVENTS } from "../shared/instance.js";
 
 // Covered origins and URLs are scoped to the Penpot web app (e.g. links in the Menu > Help & info).
 const ALLOWED_INTERNAL_ORIGINS = Object.freeze([
@@ -21,7 +22,7 @@ const ALLOWED_EXTERNAL_URLS = Object.freeze([
 	"https://github.com/penpot/penpot",
 ]);
 
-ipcMain.on("registerInstance", (event, instance) => {
+ipcMain.on(INSTANCE_EVENTS.REGISTER, (event, instance) => {
 	const { id, origin } = instance;
 	const hasValidOrigin = URL.canParse(origin);
 	if (hasValidOrigin) {
@@ -39,14 +40,23 @@ ipcMain.on("registerInstance", (event, instance) => {
 
 		settings.instances = [...settings.instances, instance];
 	} else {
-		console.warn(`[WARN] [IPC.registerInstance] Failed with: ${origin}`);
+		console.warn(
+			`[WARN] [IPC.${INSTANCE_EVENTS.REGISTER}] Failed with: ${origin}`,
+		);
 	}
 });
 
-ipcMain.on("removeInstance", (event, id) => {
+ipcMain.on(INSTANCE_EVENTS.REMOVE, (event, id) => {
 	settings.instances = settings.instances.filter(
 		({ id: registeredId }) => registeredId !== id,
 	);
+});
+
+ipcMain.on(INSTANCE_EVENTS.SET_DEFAULT, (event, id) => {
+	settings.instances = settings.instances.map((instance) => {
+		instance.isDefault = instance.id === id ? true : false;
+		return instance;
+	});
 });
 
 app.on("web-contents-created", (event, contents) => {

--- a/src/process/preload.mjs
+++ b/src/process/preload.mjs
@@ -14,8 +14,9 @@ contextBridge.exposeInMainWorld(
 				"MinimizeWindow",
 				"OpenHelp",
 				"OpenOffline",
-				"registerInstance",
-				"removeInstance",
+				"instance:register",
+				"instance:remove",
+				"instance:setDefault",
 				"openTabMenu",
 			];
 

--- a/src/process/settings.js
+++ b/src/process/settings.js
@@ -105,6 +105,11 @@ async function getUserSettings() {
 		});
 	}
 
+	const hasOneInstance = settings.instances.length === 1;
+	if (hasOneInstance) {
+		settings.instances[0].isDefault = true;
+	}
+
 	return settings;
 }
 

--- a/src/process/settings.js
+++ b/src/process/settings.js
@@ -9,6 +9,9 @@ import { readConfig, writeConfig } from "./config.js";
  *
  * @typedef {Object} Instance
  * @property {URL["origin"]} origin
+ * @property {string =} label
+ * @property {string =} color
+ * @property {boolean =} isDefault
  */
 
 const CONFIG_SETTINGS_NAME = "settings";

--- a/src/process/settings.js
+++ b/src/process/settings.js
@@ -8,6 +8,7 @@ import { readConfig, writeConfig } from "./config.js";
  * @property {Array<Instance>} instances
  *
  * @typedef {Object} Instance
+ * @property {string =} id
  * @property {URL["origin"]} origin
  * @property {string =} label
  * @property {string =} color

--- a/src/process/settings.js
+++ b/src/process/settings.js
@@ -1,40 +1,42 @@
-import { ipcMain } from "electron";
-import { deepFreeze, observe } from "../tools/object.js";
-import { readConfig, writeConfig } from "./config.js";
-
-/**
- * @typedef {Object} Settings
- * @property {'light' | 'dark' | 'system' | 'tab'} theme
- * @property {Array<Instance>} instances
- *
- * @typedef {Object} Instance
- * @property {string =} id
- * @property {URL["origin"]} origin
- * @property {string =} label
- * @property {string =} color
- * @property {boolean =} isDefault
- */
+import { app, dialog, ipcMain, shell } from "electron";
+import { observe } from "../tools/object.js";
+import { duplicateConfig, readConfig, writeConfig } from "./config.js";
+import { z, ZodError } from "zod";
+import { DEFAULT_INSTANCE } from "../shared/instance.js";
+import { getMainWindow } from "./window.js";
 
 const CONFIG_SETTINGS_NAME = "settings";
-/** @type {Settings} */
-const CONFIG_SETTINGS_DEFAULT = deepFreeze({
-	theme: "system",
-	instances: [],
-});
-const CONFIG_SETTINGS_ENTRY_NAMES = Object.freeze(
-	Object.keys(CONFIG_SETTINGS_DEFAULT),
-);
+const CONFIG_SETTINGS_ENTRY_NAMES = Object.freeze(["theme", "instances"]);
 
-/** @type {Settings} */
-export const settings = observe(
-	{
-		...CONFIG_SETTINGS_DEFAULT,
-		...(await readConfig(CONFIG_SETTINGS_NAME)),
-	},
-	(newSettings) => {
-		writeConfig(CONFIG_SETTINGS_NAME, newSettings);
-	},
-);
+const settingsSchema = z.object({
+	theme: z.enum(["light", "dark", "system", "tab"]).default("system"),
+	instances: z
+		.array(
+			z
+				.object({
+					id: z
+						.string()
+						.uuid()
+						.default(() => crypto.randomUUID()),
+					origin: z.string().url().default(DEFAULT_INSTANCE.origin),
+					label: z.string().default("Your instance"),
+					color: z.string().default(DEFAULT_INSTANCE.color),
+					isDefault: z.boolean().default(false),
+				})
+				.default({}),
+		)
+		.default([]),
+});
+
+/**
+ * @typedef {z.infer<typeof settingsSchema>} Settings
+ */
+const userSettings = await getUserSettings();
+writeConfig(CONFIG_SETTINGS_NAME, userSettings);
+
+export const settings = observe(userSettings, (newSettings) => {
+	writeConfig(CONFIG_SETTINGS_NAME, newSettings);
+});
 
 ipcMain.handle(
 	"setting:get",
@@ -74,3 +76,73 @@ ipcMain.on(
 		}
 	},
 );
+
+async function getUserSettings() {
+	let settings;
+
+	try {
+		/** @type {Settings | Record<string, unknown>} */
+		const userSettings = (await readConfig(CONFIG_SETTINGS_NAME)) || {};
+
+		settings = settingsSchema.parse(userSettings);
+	} catch (error) {
+		settings = settingsSchema.parse({});
+
+		if (error instanceof Error) {
+			duplicateConfig(CONFIG_SETTINGS_NAME, "old");
+
+			app.whenReady().then(() => {
+				showSettingsValidationIssue(error);
+			});
+		}
+	}
+
+	const hasInstances = !!settings.instances[0];
+	if (!hasInstances) {
+		settings.instances.push({
+			...DEFAULT_INSTANCE,
+			id: crypto.randomUUID(),
+		});
+	}
+
+	return settings;
+}
+
+/**
+ * @param {Error} error
+ */
+function showSettingsValidationIssue(error) {
+	const mainWindow = getMainWindow();
+
+	const isZodError = error instanceof ZodError;
+	const errorDetails =
+		(isZodError &&
+			error.issues
+				.map(({ path, message }) => {
+					const dataInfo = path.join("/");
+
+					return `${dataInfo}: ${message}`;
+				})
+				.join("\n")) ||
+		error.message;
+
+	const DIALOG_DECISIONS = Object.freeze({
+		CONFIRM: 0,
+		REPORT: 1,
+	});
+	const decision = dialog.showMessageBoxSync(mainWindow, {
+		type: "error",
+		title: "Settings Error",
+		message: `The app encountered an issue with your settings.`,
+		detail: `The settings file contains invalid data and was backed up to "settings.old.json". The app will use the default settings.\n\nReported errors:\n${errorDetails}\n\n If you didn't manually edit the settings file, please report this issue.`,
+		buttons: ["OK", "Report"],
+		defaultId: DIALOG_DECISIONS.CONFIRM,
+		cancelId: DIALOG_DECISIONS.CONFIRM,
+	});
+
+	const isReport = decision === DIALOG_DECISIONS.REPORT;
+	if (isReport) {
+		shell.openExternal("https://github.com/author-more/penpot-desktop/issues");
+		return;
+	}
+}

--- a/src/process/tsconfig.json
+++ b/src/process/tsconfig.json
@@ -1,4 +1,4 @@
 {
 	"extends": "../../tsconfig.json",
-	"include": ["**/*", "../tools", "../types"]
+	"include": ["**/*", "../tools", "../types", "../shared"]
 }

--- a/src/shared/instance.js
+++ b/src/shared/instance.js
@@ -1,0 +1,6 @@
+export const DEFAULT_INSTANCE = Object.freeze({
+	origin: "https://design.penpot.app",
+	label: "Official",
+	color: "hsla(0,0,0,0)",
+	isDefault: true,
+});

--- a/src/shared/instance.js
+++ b/src/shared/instance.js
@@ -2,5 +2,14 @@ export const DEFAULT_INSTANCE = Object.freeze({
 	origin: "https://design.penpot.app",
 	label: "Official",
 	color: "hsla(0,0,0,0)",
-	isDefault: true,
+	isDefault: false,
+});
+
+/**
+ * Preload script's have limited import possibilities, channel names have to be updated manually.
+ */
+export const INSTANCE_EVENTS = Object.freeze({
+	REGISTER: "instance:register",
+	REMOVE: "instance:remove",
+	SET_DEFAULT: "instance:setDefault",
 });

--- a/src/tools/element.js
+++ b/src/tools/element.js
@@ -1,0 +1,10 @@
+/**
+ * Checks if a node is a parent node.
+ *
+ * @param {Node} node
+ *
+ * @returns {node is ParentNode}
+ */
+export function isParentNode(node) {
+	return node.hasChildNodes();
+}

--- a/src/tools/value.js
+++ b/src/tools/value.js
@@ -1,0 +1,11 @@
+/**
+ * @template T
+ *
+ * @param {T} value
+ *
+ * @returns {value is Exclude<T, null | undefined>}
+ */
+
+export function isNonNull(value) {
+	return value !== undefined && value !== null;
+}


### PR DESCRIPTION
Added support for multiple Penpot instances.

The new feature allows users to define and open multiple Penpot instances simultaneously in different, color-coded tabs.
The context menu of the "Add Tab" button provides an option to open a specific instance.
Instances of the same origin are treated as separate, persistent sessions.
Instance management is available through the app's settings. Users can set default instances through the instance entry's context menu in the settings.