### PR TITLE
fix(linux): app to open with gnome

### DIFF
--- a/src/process/index.js
+++ b/src/process/index.js
@@ -7,6 +7,10 @@ await import("./navigation.js");
 
 app.enableSandbox();
 
+// https://www.electronjs.org/docs/latest/breaking-changes#changed-gtk-4-is-default-when-running-gnome
+// https://github.com/electron/electron/issues/46538
+app.commandLine.appendSwitch("gtk-version", "3");
+
 app.whenReady().then(() => {
 	electronUpdater.autoUpdater.checkForUpdatesAndNotify();
 	MainWindow.create();


### PR DESCRIPTION
Added a workaround for an Electron breaking change to use GTK 4 by default.