### PR TITLE
refactor: build action and release workflow

### DIFF
--- a/.github/actions/build/action.yml
+++ b/.github/actions/build/action.yml
@@ -1,0 +1,84 @@
+name: Build
+description: Build Application
+
+inputs:
+  build-os:
+    description: target OS for building Application
+    required: true
+  artifacts-paths:
+    description: paths to files to keep from artifacts
+    required: true
+    default: |
+      dist/latest*.yml
+      dist/*.exe
+      dist/*.AppImage
+      dist/*.rpm
+      dist/*.deb
+      dist/*.dmg
+      dist/*.zip
+      dist/*.blockmap
+  github-token:
+    description: GitHub token
+    required: true
+  dependencies-bot-name:
+    description: name of dependency bot (dependabot)
+    required: true
+    default: "dependabot[bot]"
+
+runs:
+  using: composite
+
+  steps:
+    - uses: actions/setup-node@v4
+      with:
+        node-version: 22
+
+    # Cache npm dependencies, creates a new cache on new versions of package-lock.json
+    - name: Cache npm dependencies
+      uses: actions/cache@v4
+      with:
+        path: ~/.npm
+        key: node-${{ inputs.build-os }}-${{ hashFiles('**/package-lock.json') }}
+
+    - name: Install dependencies
+      shell: bash
+      run: npm ci
+
+    - name: Validate commit messages - last push commit
+      if: github.event_name == 'push' && github.event.pusher.name != inputs.dependencies-bot-name
+      shell: bash
+      run: npx commitlint --last --verbose
+
+    - name: Validate commit messages - PR's commits
+      if: github.event_name == 'pull_request' && github.event.pull_request.user.login != inputs.dependencies-bot-name
+      shell: bash
+      run: npx commitlint --from "${{ github.event.pull_request.base.sha }}" --to "${{ github.event.pull_request.head.sha }}" --verbose
+
+    - name: Run code checks
+      shell: bash
+      run: npm run check
+
+    # Cache build result, creates a new cache on new commit hash
+    - name: Cache Build files
+      uses: actions/cache@v4
+      with:
+        key: build-${{ inputs.build-os }}-${{ github.event.head_commit.id || github.event.pull_request.head.sha }}
+        path: dist/
+
+    - name: Build
+      shell: bash
+      run: |
+        if [ "${{ github.head_ref || github.ref_name }}" = "main" ]; then
+          npm run build -- --x64 --arm64
+        else
+          npm run build -- --x64 --arm64 --publish=never
+        fi
+      env:
+        GH_TOKEN: ${{ inputs.github-token }}
+
+    - name: Save artifacts
+      uses: actions/upload-artifact@v4
+      with:
+        name: build-${{ inputs.build-os }}
+        path: ${{ inputs.artifacts-paths }}
+        retention-days: 1

--- a/.github/workflows/build.yml
+++ b/.github/workflows/build.yml
@@ -6,55 +6,20 @@ permissions:
   # Required for Electron Builder to create and update releases on Github
   contents: write
 
-env:
-  DEPENDENCIES_BOT_NAME: "dependabot[bot]"
-
 jobs:
   build:
     strategy:
       matrix:
         os: [ubuntu-latest, windows-latest, macos-latest]
 
-    runs-on: ${{ matrix.os}}
+    runs-on: ${{ matrix.os }}
 
     steps:
       - uses: actions/checkout@v4
         with:
           fetch-depth: 0
-      - uses: actions/setup-node@v4
+
+      - uses: ./.github/actions/build
         with:
-          node-version: 22
-      - name: Install dependencies
-        run: npm ci
-      - name: Validate commit messages - last push commit
-        if: github.event_name == 'push' && github.event.pusher.name != env.DEPENDENCIES_BOT_NAME
-        run: npx commitlint --last --verbose
-      - name: Validate commit messages - PR's commits
-        if: github.event_name == 'pull_request' && github.event.pull_request.user.login != env.DEPENDENCIES_BOT_NAME
-        run: npx commitlint --from "${{ github.event.pull_request.base.sha }}" --to "${{ github.event.pull_request.head.sha }}" --verbose
-      - name: Run code checks
-        run: npm run check
-      - name: Build
-        shell: bash
-        run: |
-          if [ "${{ github.head_ref || github.ref_name }}" = "main" ]; then
-            npm run build -- --x64 --arm64
-          else
-            npm run build -- --x64 --arm64 --publish=never
-          fi
-        env:
-          GH_TOKEN: ${{ secrets.GITHUB_TOKEN }}
-      - name: Save artifacts
-        uses: actions/upload-artifact@v4
-        with:
-          name: build-${{ matrix.os }}
-          path: |
-            dist/latest*.yml
-            dist/*.exe
-            dist/*.AppImage
-            dist/*.dmg
-            dist/*.rpm
-            dist/*.deb
-            dist/*.zip
-            dist/*.blockmap
-          retention-days: 1
+          build-os: ${{ matrix.os }}
+          github-token: ${{ secrets.GITHUB_TOKEN }}

--- a/.github/workflows/release.yml
+++ b/.github/workflows/release.yml
@@ -1,0 +1,91 @@
+name: Release
+
+on:
+  pull_request:
+    branches: [main]
+    types: [closed]
+
+permissions:
+  # Required for Electron Builder to create and update releases on Github
+  contents: write
+
+jobs:
+  build:
+    # New release is created only on merge of a branch with 'chore/release' on the 'main' branch
+    if: github.event.pull_request.merged == true && startsWith(github.head_ref, 'chore/release')
+
+    strategy:
+      matrix:
+        os: [ubuntu-latest, windows-latest, macos-latest]
+
+    runs-on: ${{ matrix.os }}
+
+    steps:
+      - uses: actions/checkout@v4
+        with:
+          fetch-depth: 0
+
+      - uses: ./.github/actions/build
+        with:
+          build-os: ${{ matrix.os }}
+          github-token: ${{ secrets.GITHUB_TOKEN }}
+
+  release:
+    needs: [build]
+    runs-on: ubuntu-latest
+
+    steps:
+      - name: Get release date and version
+        run: |
+          echo "RELEASE_DATE=$(date +'%Y-%m-%d')" >> $GITHUB_ENV
+          echo "RELEASE_VERSION=$(echo ${{ github.ref_name || github.head_ref }} | grep -oE "[0-9]+\.[0-9]+\.[0-9]+")" >> $GITHUB_ENV
+
+      - name: Get current latest release
+        uses: pozetroninc/github-action-get-latest-release@v0.8.0
+        id: latest-release
+        with:
+          repository: ${{ github.repository }}
+          token: ${{ secrets.GITHUB_TOKEN }}
+          excludes: prerelease, draft
+
+      - name: Download artifacts
+        uses: actions/download-artifact@v4
+        with:
+          path: dist
+          pattern: build-*
+          merge-multiple: true
+          github-token: ${{ secrets.GITHUB_TOKEN }}
+
+      # Filtering and renaming for easier understanding of the platforms/architectures for final users
+      - name: Rename artifacts
+        shell: bash
+        run: |
+          mkdir -p release
+          mv dist/*.aarch64.rpm    release/penpot-desktop_linux_arm64.rpm
+          mv dist/*.x86_64.rpm     release/penpot-desktop_linux_x64.rpm
+          mv dist/*_arm64.deb      release/penpot-desktop_linux_arm64.deb
+          mv dist/*_amd64.deb      release/penpot-desktop_linux_x64.deb
+          mv dist/*-arm64.AppImage release/PenpotDesktop_linux_arm64.AppImage
+          mv dist/*.AppImage       release/PenpotDesktop_linux_x64.AppImage
+          mv dist/*-arm64-mac.zip  release/PenpotDesktop_macos_arm64.app.zip
+          mv dist/*-mac.zip        release/PenpotDesktop_macos_x64.app.zip
+          mv dist/*-arm64.dmg      release/PenpotDesktop_macos_arm64.dmg
+          mv dist/*.dmg            release/PenpotDesktop_macos_x64.dmg
+          mv dist/*.exe            release/PenpotDesktop_windows_x64.exe
+
+      - name: Create Release
+        uses: softprops/action-gh-release@v2
+        with:
+          name: "v${{ env.RELEASE_VERSION }} (${{ env.RELEASE_DATE }})"
+          tag_name: v${{ env.RELEASE_VERSION }}
+          prerelease: true
+          make_latest: true
+          files: release/*
+          body: |
+            ### **Features**
+            - ...
+
+            ### **Fixed**
+            - ...
+
+            ### **Full Changelog: [${{ steps.latest-release.outputs.release }} ... ${{ env.RELEASE_VERSION }}](https://github.com/${{ github.repository }}/commits/${{ steps.latest-release.outputs.release }}...${{ env.RELEASE_VERSION }})**


### PR DESCRIPTION
Hi, very interested in this project that is the perfect complement to the Penpot project!

I'm currently working on making it available on Homebrew (#45) and handle versioning via Actions/Workflows
In order to provide a clean slate on the Actions/Workflows part of this repository, I implemented the following :
- Extract the build process into a separate and reusable `Build` action, in order to use it in multiple workflows
- Implement caching to make processes faster, while staying conservative on when to cache :
  - `npm` dependencies, caching for each state of the `package-lock.json`
  - build results, caching for each commit hash
- Change the current `Build` workflow to use the new `Build` reusable action
- New `Release` workflow that uses the `Build` reusable action and then creates a ready prerelease (including uploading build results) when a PR is merged from a `chore/release***` branch into the `main` branch, as it already works in this repository

Apart from this, the builds on every pushes and PRs works as usual, with same artifacts file structure and general behavior, the only new behavior is the `Release` workflow that is a totally separate workflow.
The workflow automatically creates a new release, the according tag, a basic description, and it is set as a `prerelease` to let maintainers add more description and video examples of new features without having to deal with the rest.
Because it represents the `Release` event it could later integrate behaviors linked to `Homebrew`, `Flathub`, and `Snap Store`

<img width="638" height="144" alt="image" src="https://github.com/user-attachments/assets/bf7c058f-6fe5-421e-89dd-4a945c3dd5cd" />

Example of the result (new release and tag entirely created in workflow) :
https://github.com/AtlasRW/penpot-desktop/releases/tag/v0.17.0

Also, when automatically uploading the build results into a new release, I took this opportunity to only filter files that are interesting for end users (`.exe`, `.dmg`, `.zip`, `.rpm`, `.deb`, `.AppImage`) and rename those in a way that makes it more clear for end users searching what is the right variant for them directly by looking at the file name (example: `PenpotDesktop_linux_x64.AppImage`) with consistent naming that doesn't integrate a dynamic value (version) that could make it way easier to provide generic download links with always the latest version (for a download page, a README, etc)

Hope you like it!