### PR TITLE
feat: migrate to valkey for ws notifications

### DIFF
--- a/bin/docker-compose.yaml
+++ b/bin/docker-compose.yaml
@@ -114,7 +114,7 @@ services:
     depends_on:
       penpot-postgres:
         condition: service_healthy
-      penpot-redis:
+      penpot-valkey:
         condition: service_healthy
 
     networks:
@@ -151,10 +151,10 @@ services:
       PENPOT_DATABASE_USERNAME: penpot
       PENPOT_DATABASE_PASSWORD: penpot
 
-      ## Redis is used for the websockets notifications. Don't touch unless the redis
-      ## container has different parameters or different name.
+      ## Valkey (or previously redis) is used for the websockets notifications. Don't touch
+      ## unless the valkey container has different parameters or different name.
 
-      PENPOT_REDIS_URI: redis://penpot-redis/0
+      PENPOT_REDIS_URI: redis://penpot-valkey/0
 
       ## Default configuration for assets storage: using filesystem based with all files
       ## stored in a docker volume.
@@ -198,7 +198,7 @@ services:
     restart: always
 
     depends_on:
-      penpot-redis:
+      penpot-valkey:
         condition: service_healthy
 
     networks:
@@ -209,8 +209,8 @@ services:
       # communicate with the frontend.
       PENPOT_PUBLIC_URI: http://penpot-frontend:8080
 
-      ## Redis is used for the websockets notifications.
-      PENPOT_REDIS_URI: redis://penpot-redis/0
+      ## Valkey (or previously Redis) is used for the websockets notifications.
+      PENPOT_REDIS_URI: redis://penpot-valkey/0
 
   penpot-postgres:
     image: "postgres:15"
@@ -236,12 +236,12 @@ services:
       - POSTGRES_USER=penpot
       - POSTGRES_PASSWORD=penpot
 
-  penpot-redis:
-    image: redis:7.2
+  penpot-valkey:
+    image: valkey/valkey:8.1
     restart: always
 
     healthcheck:
-      test: ["CMD-SHELL", "redis-cli ping | grep PONG"]
+      test: ["CMD-SHELL", "valkey-cli ping | grep PONG"]
       interval: 1s
       timeout: 3s
       retries: 5


### PR DESCRIPTION
Following the official self-hosting configuration, web socket notifications have been migrated from Redis to Valkey.