### PR TITLE
build: migrate icons to project's assets

### DIFF
--- a/package-lock.json
+++ b/package-lock.json
@@ -15,7 +15,6 @@
 				"electron-updater": "^6.6.2",
 				"electron-window-state": "^5.0.3",
 				"jszip": "^3.10.1",
-				"lucide-static": "^0.546.0",
 				"zod": "^4.1.12"
 			},
 			"devDependencies": {
@@ -6069,12 +6068,6 @@
 			"engines": {
 				"node": ">=10"
 			}
-		},
-		"node_modules/lucide-static": {
-			"version": "0.546.0",
-			"resolved": "https://registry.npmjs.org/lucide-static/-/lucide-static-0.546.0.tgz",
-			"integrity": "sha512-9nZdgIRqLVsoqbSpSf+tRUbieA/y1eVvsN20ecBI8MKDay7XC4fy0MsNFXhiOddk419s7IgtEOvlf+nFWWPqoA==",
-			"license": "ISC"
 		},
 		"node_modules/make-fetch-happen": {
 			"version": "10.2.1",

--- a/package.json
+++ b/package.json
@@ -42,7 +42,6 @@
 		"electron-updater": "^6.6.2",
 		"electron-window-state": "^5.0.3",
 		"jszip": "^3.10.1",
-		"lucide-static": "^0.546.0",
 		"zod": "^4.1.12"
 	},
 	"devDependencies": {

--- a/src/base/assets/icons/lucide/chevron-left.svg
+++ b/src/base/assets/icons/lucide/chevron-left.svg
@@ -1,0 +1,15 @@
+<!-- @license lucide-static v0.546.0 - ISC -->
+<svg
+  class="lucide lucide-chevron-left"
+  xmlns="http://www.w3.org/2000/svg"
+  width="24"
+  height="24"
+  viewBox="0 0 24 24"
+  fill="none"
+  stroke="currentColor"
+  stroke-width="2"
+  stroke-linecap="round"
+  stroke-linejoin="round"
+>
+  <path d="m15 18-6-6 6-6" />
+</svg>

--- a/src/base/assets/icons/lucide/circle-plus.svg
+++ b/src/base/assets/icons/lucide/circle-plus.svg
@@ -1,0 +1,17 @@
+<!-- @license lucide-static v0.546.0 - ISC -->
+<svg
+  class="lucide lucide-circle-plus"
+  xmlns="http://www.w3.org/2000/svg"
+  width="24"
+  height="24"
+  viewBox="0 0 24 24"
+  fill="none"
+  stroke="currentColor"
+  stroke-width="2"
+  stroke-linecap="round"
+  stroke-linejoin="round"
+>
+  <circle cx="12" cy="12" r="10" />
+  <path d="M8 12h8" />
+  <path d="M12 8v8" />
+</svg>

--- a/src/base/assets/icons/lucide/rotate-cw.svg
+++ b/src/base/assets/icons/lucide/rotate-cw.svg
@@ -1,0 +1,16 @@
+<!-- @license lucide-static v0.546.0 - ISC -->
+<svg
+  class="lucide lucide-rotate-cw"
+  xmlns="http://www.w3.org/2000/svg"
+  width="24"
+  height="24"
+  viewBox="0 0 24 24"
+  fill="none"
+  stroke="currentColor"
+  stroke-width="2"
+  stroke-linecap="round"
+  stroke-linejoin="round"
+>
+  <path d="M21 12a9 9 0 1 1-9-9c2.52 0 4.93 1 6.74 2.74L21 8" />
+  <path d="M21 3v5h-5" />
+</svg>

--- a/src/base/assets/icons/lucide/settings.svg
+++ b/src/base/assets/icons/lucide/settings.svg
@@ -1,0 +1,16 @@
+<!-- @license lucide-static v0.546.0 - ISC -->
+<svg
+  class="lucide lucide-settings"
+  xmlns="http://www.w3.org/2000/svg"
+  width="24"
+  height="24"
+  viewBox="0 0 24 24"
+  fill="none"
+  stroke="currentColor"
+  stroke-width="2"
+  stroke-linecap="round"
+  stroke-linejoin="round"
+>
+  <path d="M9.671 4.136a2.34 2.34 0 0 1 4.659 0 2.34 2.34 0 0 0 3.319 1.915 2.34 2.34 0 0 1 2.33 4.033 2.34 2.34 0 0 0 0 3.831 2.34 2.34 0 0 1-2.33 4.033 2.34 2.34 0 0 0-3.319 1.915 2.34 2.34 0 0 1-4.659 0 2.34 2.34 0 0 0-3.32-1.915 2.34 2.34 0 0 1-2.33-4.033 2.34 2.34 0 0 0 0-3.831A2.34 2.34 0 0 1 6.35 6.051a2.34 2.34 0 0 0 3.319-1.915" />
+  <circle cx="12" cy="12" r="3" />
+</svg>

--- a/src/base/assets/icons/lucide/square-x.svg
+++ b/src/base/assets/icons/lucide/square-x.svg
@@ -1,0 +1,17 @@
+<!-- @license lucide-static v0.546.0 - ISC -->
+<svg
+  class="lucide lucide-square-x"
+  xmlns="http://www.w3.org/2000/svg"
+  width="24"
+  height="24"
+  viewBox="0 0 24 24"
+  fill="none"
+  stroke="currentColor"
+  stroke-width="2"
+  stroke-linecap="round"
+  stroke-linejoin="round"
+>
+  <rect width="18" height="18" x="3" y="3" rx="2" ry="2" />
+  <path d="m15 9-6 6" />
+  <path d="m9 9 6 6" />
+</svg>

--- a/src/base/assets/icons/lucide/wand-sparkles.svg
+++ b/src/base/assets/icons/lucide/wand-sparkles.svg
@@ -1,0 +1,22 @@
+<!-- @license lucide-static v0.546.0 - ISC -->
+<svg
+  class="lucide lucide-wand-sparkles"
+  xmlns="http://www.w3.org/2000/svg"
+  width="24"
+  height="24"
+  viewBox="0 0 24 24"
+  fill="none"
+  stroke="currentColor"
+  stroke-width="2"
+  stroke-linecap="round"
+  stroke-linejoin="round"
+>
+  <path d="m21.64 3.64-1.28-1.28a1.21 1.21 0 0 0-1.72 0L2.36 18.64a1.21 1.21 0 0 0 0 1.72l1.28 1.28a1.2 1.2 0 0 0 1.72 0L21.64 5.36a1.2 1.2 0 0 0 0-1.72" />
+  <path d="m14 7 3 3" />
+  <path d="M5 6v4" />
+  <path d="M19 14v4" />
+  <path d="M10 2v2" />
+  <path d="M7 8H3" />
+  <path d="M21 16h-4" />
+  <path d="M11 3H9" />
+</svg>

--- a/src/base/scripts/shoelace.js
+++ b/src/base/scripts/shoelace.js
@@ -5,5 +5,5 @@ import { registerIconLibrary } from "../../../node_modules/@shoelace-style/shoel
 setBasePath("../../node_modules/@shoelace-style/shoelace/cdn");
 
 registerIconLibrary("lucide", {
-	resolver: (name) => `../../node_modules/lucide-static/icons/${name}.svg`,
+	resolver: (name) => `./assets/icons/lucide/${name}.svg`,
 });


### PR DESCRIPTION
Removed npm package dependency and added the set of used icons as the project's assets.