### PR TITLE
chore: trigger release

### DIFF
--- a/build/flatpak/com.authormore.penpotdesktop.metainfo.xml
+++ b/build/flatpak/com.authormore.penpotdesktop.metainfo.xml
@@ -53,7 +53,7 @@
         <internet>offline-only</internet>
     </supports>
     <releases>
-		    <release version="v0.24.0" date="2026-08-26">
+		    <release version="v0.24.0" date="2026-08-27">
             <url type="details">https://github.com/author-more/penpot-desktop/releases/tag/v0.24.0</url>
             <description>
                 <p>Features</p>


### PR DESCRIPTION
Triggering release which failed due to [Actions](https://www.githubstatus.com/incidents/y1t7p9fzrlj2) and [PRs](https://www.githubstatus.com/incidents/kfspvrz14xr0) issues on 26.08.2026. 