### PR TITLE
feat: add non destructive settings

### DIFF
--- a/src/process/config.js
+++ b/src/process/config.js
@@ -1,13 +1,15 @@
 import { app } from "electron";
-import { copyFile, readFile, writeFile } from "node:fs/promises";
+import { readFile, writeFile } from "node:fs/promises";
 import { join } from "node:path";
 
+export class ConfigReadError extends Error {
+	name = "ConfigReadError";
+}
+
 /**
- * @template Config
- *
  * @param {string} configName
  *
- * @returns {Promise<Config | undefined>}
+ * @returns {Promise<unknown>}
  */
 export async function readConfig(configName) {
 	const configFilePath = getConfigFilePath(configName);
@@ -23,7 +25,7 @@ export async function readConfig(configName) {
 		const message = `[ERROR] [config:read:${configName}] ${isError ? error.message : "Failed to read config."}`;
 
 		if (isError && !isNoFile) {
-			throw new Error(message, {
+			throw new ConfigReadError(message, {
 				cause: error,
 			});
 		}
@@ -33,10 +35,8 @@ export async function readConfig(configName) {
 }
 
 /**
- * @template Config
- *
  * @param {string} configName
- * @param {Partial<Config>} config
+ * @param {Record<string, unknown>} config
  */
 export function writeConfig(configName, config) {
 	const configFilePath = getConfigFilePath(configName);
@@ -46,35 +46,13 @@ export function writeConfig(configName, config) {
 		writeFile(configFilePath, configJSON, "utf8");
 	} catch (error) {
 		const isError = error instanceof Error;
-		const message = isError ? error.message : "Failed to save the  config.";
+		const message = isError ? error.message : "Failed to save the config.";
 		console.error(`[ERROR] [config:write:${configName}] ${message}`);
 	}
 }
 
 /**
  * @param {string} configName
- * @param {string =} suffix
- */
-export function duplicateConfig(configName, suffix) {
-	const configFilePath = getConfigFilePath(configName);
-	const modifier = suffix ? `.${suffix}` : "";
-	const configFileCopyPath = getConfigFilePath(`${configName}${modifier}`);
-
-	try {
-		copyFile(configFilePath, configFileCopyPath);
-	} catch (error) {
-		const isError = error instanceof Error;
-		const message = isError
-			? error.message
-			: "Failed to duplicate the  config.";
-		console.error(`[ERROR] [config:duplicate:${configName}] ${message}`);
-	}
-}
-
-/**
- * @param {string} configName
- *
- * @returns
  */
 function getConfigFilePath(configName) {
 	const configDir = app.getPath("userData");

--- a/src/process/config.js
+++ b/src/process/config.js
@@ -22,7 +22,7 @@ export async function readConfig(configName) {
 	} catch (error) {
 		const isError = error instanceof Error;
 		const isNoFile = isError && "code" in error && error.code === "ENOENT";
-		const message = `[ERROR] [config:read:${configName}] ${isError ? error.message : "Failed to read config."}`;
+		const message = isError ? error.message : "Failed to read config.";
 
 		if (isError && !isNoFile) {
 			throw new ConfigReadError(message, {
@@ -30,7 +30,7 @@ export async function readConfig(configName) {
 			});
 		}
 
-		console.error(message);
+		console.error(`[ERROR] [config:read:${configName}] ${message}`);
 	}
 }
 

--- a/src/process/instance.js
+++ b/src/process/instance.js
@@ -331,7 +331,6 @@ function registerInstance(instance) {
 }
 
 async function getInstancesConfig() {
-	/** @type {LocalInstances | Record<string, unknown>} */
 	const instancesConfig = (await readConfig(CONFIG_INSTANCES_NAME)) || {};
 
 	return instancesConfigSchema.parse(instancesConfig);

--- a/src/process/settings.js
+++ b/src/process/settings.js
@@ -1,6 +1,6 @@
 import { app, dialog, ipcMain, shell } from "electron";
-import { observe } from "../tools/object.js";
-import { duplicateConfig, readConfig, writeConfig } from "./config.js";
+import { getChangedProperties, isRecord, observe } from "../tools/object.js";
+import { ConfigReadError, readConfig, writeConfig } from "./config.js";
 import { z, ZodError } from "zod";
 import { DEFAULT_INSTANCE } from "../shared/instance.js";
 import { getMainWindow } from "./window.js";
@@ -9,67 +9,98 @@ import { CONFIG_SETTINGS_TITLE_BAR_TYPES } from "../shared/settings.js";
 import { instanceIdSchema } from "./instance.js";
 
 const CONFIG_SETTINGS_NAME = "settings";
-const CONFIG_SETTINGS_ENTRY_NAMES = Object.freeze([
-	"theme",
-	"titleBarType",
-	"instances",
-	"enableTabsRemembering",
-	"enableAutoReload",
-	"enableViewModeWindow",
-]);
 
 const titleBarTypes = Object.values(CONFIG_SETTINGS_TITLE_BAR_TYPES);
 
-const settingsSchema = z.object({
-	theme: z.enum(["light", "dark", "system", "tab"]).default("system"),
-	titleBarType: z
-		.enum([titleBarTypes[0], ...titleBarTypes.slice(1)])
-		.optional()
-		.default(CONFIG_SETTINGS_TITLE_BAR_TYPES.OVERLAY),
-	enableTabsRemembering: z.boolean().default(false),
-	enableAutoReload: z.boolean().default(false),
-	enableViewModeWindow: z.boolean().default(false),
-	instances: z
-		.array(
-			z
-				.object({
-					id: instanceIdSchema.default(() => crypto.randomUUID()),
-					origin: z.url().default(DEFAULT_INSTANCE.origin),
-					label: z.string().default("Your instance"),
-					color: z
-						.string()
-						.trim()
-						// For settings with the old, invalid, default color value, updates the setting and prevents the settings invalidation.
-						.transform((value) => {
-							const isOldDefault = value === "hsla(0,0,0,0)";
+const instanceSchema = z
+	.object({
+		id: instanceIdSchema.default(() => crypto.randomUUID()),
+		origin: z.url().default(DEFAULT_INSTANCE.origin),
+		label: z.string().default("Your instance"),
+		color: z
+			.string()
+			.trim()
+			// For settings with the old, invalid, default color value, updates the setting and prevents the settings invalidation.
+			.transform((value) =>
+				value === "hsla(0,0,0,0)" ? DEFAULT_INSTANCE.color : value,
+			)
+			.pipe(
+				z
+					.string()
+					.regex(
+						HSLA_REGEXP,
+						`Invalid format. Currently, only the legacy format (with comma separated values), without optional units (deg), is supported. For example, ${DEFAULT_INSTANCE.color}.`,
+					),
+			)
+			.default(DEFAULT_INSTANCE.color),
+		isDefault: z.boolean().default(false),
+	})
+	.prefault({});
 
-							return isOldDefault ? DEFAULT_INSTANCE.color : value;
-						})
-						.pipe(
-							z
-								.string()
-								.regex(
-									HSLA_REGEXP,
-									`Invalid format. Currently, only the legacy format (with comma separated values), without optional units (deg), is supported. For example, ${DEFAULT_INSTANCE.color}.`,
-								),
-						)
-						.default(DEFAULT_INSTANCE.color),
-					isDefault: z.boolean().default(false),
-				})
-				.prefault({}),
-		)
-		.default([]),
+/**
+ * Schemas kept as a record for a per-key validation.
+ */
+const settingsShape = Object.freeze({
+	theme: z.enum(["light", "dark", "system", "tab"]),
+	titleBarType: z.enum([titleBarTypes[0], ...titleBarTypes.slice(1)]),
+	enableTabsRemembering: z.boolean(),
+	enableAutoReload: z.boolean(),
+	enableViewModeWindow: z.boolean(),
+	instances: z.array(instanceSchema),
 });
 
 /**
- * @typedef {z.infer<typeof settingsSchema>} Settings
+ * @typedef {z.infer<z.ZodObject<typeof settingsShape>>} Settings
+ * @typedef {{ key?: string, error: unknown }} ConfigError
  */
-const userSettings = await getUserSettings();
-writeConfig(CONFIG_SETTINGS_NAME, userSettings);
 
-export const settings = observe(userSettings, (newSettings) => {
-	writeConfig(CONFIG_SETTINGS_NAME, newSettings);
+/** @type {Settings} */
+const DEFAULT_SETTINGS = Object.freeze({
+	theme: "system",
+	titleBarType: CONFIG_SETTINGS_TITLE_BAR_TYPES.OVERLAY,
+	enableTabsRemembering: false,
+	enableAutoReload: false,
+	enableViewModeWindow: false,
+	instances: [],
 });
+
+const {
+	raw: rawSettings,
+	accepted: acceptedSettings,
+	errors,
+} = await getUserSettings();
+const initialSettings = normalize({
+	...DEFAULT_SETTINGS,
+	...acceptedSettings,
+});
+
+/**
+ * Writes are suspended when the file couldn't be read. Since contents are unknown, overwriting would discard whatever the user has set.
+ */
+const canSaveConfig = !hasConfigReadError(errors);
+
+/**
+ * In-operation settings config consist of accepted (known and valid) properties. On save, the config's all properties are retained and overwritten only with accepted properties that have changed (overwriting an  invalid property only if the user changed that setting).
+ *
+ * E.g. `{ theme: "lig", customProperty: true, enableTabsRemembering: true }`. User can change `enableTabsRemembering` setting, without losing `theme`'s invalid value (typo "lig" instead of "light") they set manually. However, `theme` will be fixed (overwritten) if they change the setting through the application's UI. Unknown property, like `customProperty`, is retained.
+ */
+export const settings = observe(structuredClone(initialSettings), (current) => {
+	if (!canSaveConfig) {
+		return;
+	}
+
+	writeConfig(CONFIG_SETTINGS_NAME, {
+		...rawSettings,
+		...getChangedProperties(current, initialSettings),
+	});
+});
+
+const hasErrors = !!errors.length;
+if (hasErrors) {
+	app.whenReady().then(() => {
+		showSettingsIssues(errors);
+	});
+}
 
 ipcMain.handle(
 	"setting:get",
@@ -83,9 +114,7 @@ ipcMain.handle(
 	 * @returns {Settings[S] | undefined}
 	 */
 	(_event, setting) => {
-		const isAllowedSetting = CONFIG_SETTINGS_ENTRY_NAMES.includes(setting);
-
-		if (isAllowedSetting) {
+		if (isAllowedSetting(setting)) {
 			return settings[setting];
 		}
 	},
@@ -102,67 +131,154 @@ ipcMain.on(
 	 * @param {Settings[S]} value
 	 */
 	(_event, setting, value) => {
-		const isAllowedSetting = CONFIG_SETTINGS_ENTRY_NAMES.includes(setting);
-
-		if (isAllowedSetting) {
+		if (isAllowedSetting(setting)) {
 			settings[setting] = value;
 		}
 	},
 );
 
+/**
+ * @returns {Promise<{
+ *   raw: Record<string, unknown>,
+ *   accepted: Partial<Settings>,
+ *   errors: ConfigError[],
+ * }>}
+ */
 async function getUserSettings() {
-	let settings;
-
 	try {
-		/** @type {Settings | Record<string, unknown>} */
-		const userSettings = (await readConfig(CONFIG_SETTINGS_NAME)) || {};
+		const raw = (await readConfig(CONFIG_SETTINGS_NAME)) ?? {};
 
-		settings = settingsSchema.parse(userSettings);
+		if (!isRecord(raw)) {
+			throw new ConfigReadError(
+				"Expected the settings file to contain an object.",
+			);
+		}
+
+		return { raw, ...validateSettings(raw) };
 	} catch (error) {
-		settings = settingsSchema.parse({});
+		const readError =
+			error instanceof ConfigReadError
+				? error
+				: new ConfigReadError("Failed to read the settings file.", {
+						cause: error,
+					});
 
-		if (error instanceof Error) {
-			duplicateConfig(CONFIG_SETTINGS_NAME, "old");
+		return { raw: {}, accepted: {}, errors: [{ error: readError }] };
+	}
+}
 
-			app.whenReady().then(() => {
-				showSettingsValidationIssue(error);
-			});
+/**
+ * Validates the config setting by setting. Rejected settings are left out.
+ *
+ * @param {Record<string, unknown>} rawConfig
+ *
+ * @returns {{ accepted: Partial<Settings>, errors: ConfigError[] }}
+ */
+function validateSettings(rawConfig) {
+	/** @type {Partial<Settings>} */
+	const accepted = {};
+	/** @type {ConfigError[]} */
+	const errors = [];
+
+	for (const [key, value] of Object.entries(rawConfig)) {
+		if (!isAllowedSetting(key)) {
+			continue;
+		}
+
+		const isInstances = key === "instances";
+		if (isInstances && Array.isArray(value)) {
+			const result = validateInstances(value);
+
+			accepted.instances = result.valid;
+			errors.push(...result.errors);
+
+			continue;
+		}
+
+		const result = settingsShape[key].safeParse(value);
+
+		if (result.success) {
+			accepted[key] = /** @type {never} */ (result.data);
+		} else {
+			errors.push({ key, error: result.error });
 		}
 	}
 
-	const hasInstances = !!settings.instances[0];
+	return { accepted, errors };
+}
+
+/**
+ * @param {unknown[]} entries
+ *
+ * @returns {{ valid: Settings["instances"], errors: ConfigError[] }}
+ */
+function validateInstances(entries) {
+	/** @type {Settings["instances"]} */
+	const valid = [];
+	/** @type {ConfigError[]} */
+	const errors = [];
+
+	entries.forEach((entry, index) => {
+		const result = instanceSchema.safeParse(entry);
+
+		if (result.success) {
+			valid.push(result.data);
+		} else {
+			errors.push({ key: `instances/${index}`, error: result.error });
+		}
+	});
+
+	return { valid, errors };
+}
+
+/**
+ * @param {Settings} settings
+ *
+ * @returns {Settings}
+ */
+function normalize(settings) {
+	const settingsNormalized = structuredClone(settings);
+
+	const hasInstances = !!settingsNormalized.instances[0];
 	if (!hasInstances) {
-		settings.instances.push({
+		settingsNormalized.instances.push({
 			...DEFAULT_INSTANCE,
 			id: crypto.randomUUID(),
 		});
 	}
 
-	const hasOneInstance = settings.instances.length === 1;
+	const hasOneInstance = settingsNormalized.instances.length === 1;
 	if (hasOneInstance) {
-		settings.instances[0].isDefault = true;
+		settingsNormalized.instances[0].isDefault = true;
 	}
 
-	return settings;
+	return settingsNormalized;
 }
 
 /**
- * @param {Error} error
+ * Returns true if a setting name is a know property from settings config's shape.
+ *
+ * @param {string} key
+ *
+ * @returns {key is keyof Settings}
  */
-function showSettingsValidationIssue(error) {
+function isAllowedSetting(key) {
+	return typeof key === "string" && key in settingsShape;
+}
+
+/**
+ * Shows a dialog about settings config's issues, with errors' details.
+ *
+ * @param {ConfigError[]} errors
+ */
+function showSettingsIssues(errors) {
 	const mainWindow = getMainWindow();
 
-	const isZodError = error instanceof ZodError;
-	const errorDetails =
-		(isZodError &&
-			error.issues
-				.map(({ path, message }) => {
-					const dataInfo = path.join("/");
-
-					return `${dataInfo}: ${message}`;
-				})
-				.join("\n")) ||
-		error.message;
+	const hasReadError = hasConfigReadError(errors);
+	const errorDetails = errors.map(formatConfigError).join("\n");
+	const detail = hasReadError
+		? `The settings file couldn't be read, the app will use the default settings. Your file has been left untouched and settings won't be saved. Fix or remove the corrupted settings file and restart the app to restore settings persistence.`
+		: `The settings file contains invalid entries and the app will use the default settings in their place. Your file has been left untouched. Correct the entries and restart the app to apply them.`;
 
 	const DIALOG_DECISIONS = Object.freeze({
 		CONFIRM: 0,
@@ -171,8 +287,8 @@ function showSettingsValidationIssue(error) {
 	const decision = dialog.showMessageBoxSync(mainWindow, {
 		type: "error",
 		title: "Settings Error",
-		message: `The app encountered an issue with your settings.`,
-		detail: `The settings file contains invalid data and was backed up to "settings.old.json". The app will use the default settings.\n\nReported errors:\n${errorDetails}\n\n If you didn't manually edit the settings file, please report this issue.`,
+		message: "The app encountered an issue with your settings.",
+		detail: `${detail}\n\nReported errors:\n${errorDetails}\n\nIf you didn't manually edit the settings file, please report this issue.`,
 		buttons: ["OK", "Report"],
 		defaultId: DIALOG_DECISIONS.CONFIRM,
 		cancelId: DIALOG_DECISIONS.CONFIRM,
@@ -183,4 +299,35 @@ function showSettingsValidationIssue(error) {
 		shell.openExternal("https://github.com/author-more/penpot-desktop/issues");
 		return;
 	}
+}
+
+/**
+ * Converts an error into a human readble string.
+ *
+ * @param {ConfigError} configError
+ *
+ * @returns {string}
+ */
+function formatConfigError({ key, error }) {
+	if (error instanceof ZodError) {
+		return error.issues
+			.map(
+				({ path, message }) =>
+					`${[key, ...path].filter((part) => part !== undefined && part !== "").join("/")}: ${message}`,
+			)
+			.join("\n");
+	}
+
+	const message = error instanceof Error ? error.message : String(error);
+
+	return [key, message]
+		.filter((part) => part !== undefined && part !== "")
+		.join(": ");
+}
+
+/**
+ * @param {ConfigError[]} errors
+ */
+function hasConfigReadError(errors) {
+	return errors.some(({ error }) => error instanceof ConfigReadError);
 }

--- a/src/tools/object.js
+++ b/src/tools/object.js
@@ -1,3 +1,5 @@
+import { isDeepStrictEqual } from "node:util";
+
 /**
  * Deep freeze an object.
  *
@@ -71,4 +73,37 @@ export function observe(obj, callback) {
 	};
 
 	return new Proxy(obj, handler);
+}
+
+/**
+ * Creates a record of properties that have changed between "current" and "initial" objects.
+ *
+ * @template {Record<string, unknown>} O
+ *
+ * @param {O} current
+ * @param {O} initial
+ *
+ * @returns {Partial<O>}
+ */
+export function getChangedProperties(current, initial) {
+	/** @type {Partial<O>} */
+	const changed = {};
+
+	for (const key of /** @type {(keyof O)[]} */ (Object.keys(initial))) {
+		const hasChanged = !isDeepStrictEqual(current[key], initial[key]);
+		if (hasChanged) {
+			changed[key] = current[key];
+		}
+	}
+
+	return changed;
+}
+
+/**
+ * @param {unknown} value
+ *
+ * @returns {value is Record<string, unknown>}
+ */
+export function isRecord(value) {
+	return typeof value === "object" && value !== null && !Array.isArray(value);
 }


### PR DESCRIPTION
The change upgrades the application's user settings configuration, making the settings retrieval non-destructive, where invalid or unknown entries are unused but preserved. It replaces the old solution where the config file was duplicated into a backup file, and allows editing `settings.json` manually more safely.