### PR TITLE
fix: dev tools to open for the app window

### DIFF
--- a/src/process/menu.js
+++ b/src/process/menu.js
@@ -120,7 +120,13 @@ export function setAppMenu() {
 					mainWindow.reload();
 				},
 			},
-			{ role: "toggleDevTools" },
+			{
+				label: "Open Developer Tools",
+				accelerator: "CmdOrCtrl+Shift+I",
+				click: () => {
+					mainWindow.webContents.openDevTools();
+				},
+			},
 			{
 				label: "Open Tab Developer Tools",
 				accelerator: "CmdOrCtrl+Shift+D",


### PR DESCRIPTION
By default, the toggle opens devtools for a tabbed webview's web contents. The change sets the target explicitly to the main window.